### PR TITLE
Add ability to save configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ ex_rpg-*.tar
 
 # Ignore built CLI
 ex_rpg
+
+# Ignore custom/local rule system configs
+/local_system_configs/

--- a/lib/globals.ex
+++ b/lib/globals.ex
@@ -4,6 +4,7 @@ defmodule ExRPG.Globals do
   """
   @project_root File.cwd!()
   @system_configs_path Path.join(~w(#{@project_root} priv system_configs))
+  @local_system_configs_path Path.join(~w(#{@project_root} local_system_configs))
   @license_file_name "license.md"
   @json_file_pattern ~r/.+\.json$/
 
@@ -31,6 +32,19 @@ defmodule ExRPG.Globals do
   """
   def system_configs_path do
     @system_configs_path
+  end
+
+  @doc """
+  The path to where custom rule system configs are stored
+
+  ## Examples
+
+      iex> ExRPG.Globals.local_system_configs_path()
+      "/full/path/to/project/ex_rpg/local_system_configs"
+
+  """
+  def local_system_configs_path do
+    @local_system_configs_path
   end
 
   @doc """

--- a/lib/rule_systems.ex
+++ b/lib/rule_systems.ex
@@ -51,6 +51,38 @@ defmodule ExRPG.RuleSystems do
   end
 
   @doc """
+  Checks if the given system is a bundled system
+
+  ## Examples
+
+      iex> ExRPG.RuleSystems.is_bundled_system?("dnd_5e_srd")
+      true
+
+      iex> ExRPG.RuleSystems.is_bundled_system?("my_custom_rule_system")
+      false
+  """
+  def is_bundled_system?(system) when is_bitstring(system) do
+    list_bundled_systems()
+    |> Enum.any?(fn configured_system -> configured_system == system end)
+  end
+
+  @doc """
+  Checks if the given system is a local system
+
+  ## Examples
+
+      iex> ExRPG.RuleSystems.is_local_system?("dnd_5e_srd")
+      false
+
+      iex> ExRPG.RuleSystems.is_local_system?("my_custom_rule_system")
+      true
+  """
+  def is_local_system?(system) when is_bitstring(system) do
+    list_local_systems()
+    |> Enum.any?(fn configured_system -> configured_system == system end)
+  end
+
+  @doc """
   Checks if the given system is configured.
   Returns true if system is configured, otherwise false.
 

--- a/lib/rule_systems.ex
+++ b/lib/rule_systems.ex
@@ -19,7 +19,35 @@ defmodule ExRPG.RuleSystems do
       ["dnd_5e_srd"]
   """
   def list_systems do
+    list_bundled_systems() ++ list_local_systems()
+  end
+
+  @doc """
+  List the ExRPG local custom systems available
+
+  ## Examples
+
+      iex> ExRPG.RuleSystems.list_bundled_systems()
+      ["dnd_5e_srd"]
+  """
+  def list_bundled_systems do
     File.ls!(Globals.system_configs_path())
+  end
+
+  @doc """
+  List the ExRPG bundled systems available
+
+  ## Examples
+
+      iex> ExRPG.RuleSystems.list_local_systems()
+      []
+  """
+  def list_local_systems do
+    if File.exists?(Globals.local_system_configs_path()) do
+      File.ls!(Globals.local_system_configs_path())
+    else
+      []
+    end
   end
 
   @doc """

--- a/lib/rule_systems.ex
+++ b/lib/rule_systems.ex
@@ -85,4 +85,40 @@ defmodule ExRPG.RuleSystems do
     |> Poison.encode!()
     |> RuleSystem.from_json!()
   end
+
+  @doc """
+  Saves the system specification locally as a JSON file
+
+  ## Examples
+
+      iex> ExRPG>RuleSystems.save_system!(%ExRPG.RuleSystems.RuleSystem{})
+      :ok
+
+      iex> ExRPG>RuleSystems.save_system!(%ExRPG.RuleSystems.RuleSystem{})
+      :error, :config_already_exists
+
+      iex> ExRPG>RuleSystems.save_system!(%ExRPG.RuleSystems.RuleSystem{}, true)
+      :ok
+  """
+  def save_system!(
+        %RuleSystem{metadata: %RuleSystems.Metadata{slug: system_slug}} = system,
+        overwrite \\ false
+      ) do
+    if not is_configured?(system_slug) or overwrite do
+      system_path = system_path!(system_slug)
+
+      # if `overwrite` delete system dir
+      # also... this seems incredibly dangerous
+      if overwrite do
+        File.rm_rf!(system_path)
+      end
+
+      # create the dir if it doesn't exist
+      File.mkdir_p!(system_path)
+      # write the system config to file
+      File.write!(Path.join(system_path, "system.json"), Poison.encode!(system), [:binary])
+    else
+      raise "System already exists"
+    end
+  end
 end

--- a/lib/rule_systems.ex
+++ b/lib/rule_systems.ex
@@ -118,7 +118,11 @@ defmodule ExRPG.RuleSystems do
       "/full/path/to/project/ex_rpg/system_configs/dnd_5e_srd"
   """
   def system_path!(system) when is_bitstring(system) do
-    Path.join([Globals.system_configs_path(), system])
+    if is_bundled_system?(system) do
+      Path.join([Globals.system_configs_path(), system])
+    else
+      Path.join([Globals.local_system_configs_path(), system])
+    end
   end
 
   @doc """


### PR DESCRIPTION
## Is there an associated github issue?

No

## What is this PR changing?

This PR adds the ability for one to save configs. As a side affect this PR introduces the concept of bundled vs local custom configs. Bundled configs are the ones distributed by default with the package in [priv/system_configs](https://github.com/QMalcolm/ex_rpg/tree/main/priv/system_configs). Local custom configs are stored in `local_system_configs` which is git ignored.