### PR TITLE
fix: prevent raising error when listing characters before creation

### DIFF
--- a/lib/characters.ex
+++ b/lib/characters.ex
@@ -80,9 +80,12 @@ defmodule ExTTRPGDev.Characters do
       [%Character{}, %Character{}, ...]
   """
   def list_characters!() do
-    Globals.characters_path()
-    |> File.ls!()
-    |> Enum.map(fn x -> String.trim_trailing(x, ".json") end)
+    if File.exists?(Globals.characters_path()) do
+      File.ls!(Globals.characters_path())
+      |> Enum.map(fn x -> String.trim_trailing(x, ".json") end)
+    else
+      []
+    end
   end
 
   @doc """


### PR DESCRIPTION
If you attempted to list characters before any character had been created you'd get an error like
```bash
** (File.Error) could not list directory "/home/qmalcolm/Vault/Developer/ttrpg-dev/ex_ttrpg_dev/local_characters": no such file or directory
    (elixir 1.19.5) lib/file.ex:2064: File.ls!/1
    (ex_ttrpg_dev 0.5.0) lib/characters.ex:93: ExTTRPGDev.Characters.list_characters!/0
    (ex_ttrpg_dev 0.5.0) lib/cli/characters.ex:67: ExTTRPGDev.CLI.Characters.handle_characters_subcommands/2
    (elixir 1.19.5) lib/kernel/cli.ex:141: anonymous fn/3 in Kernel.CLI.exec_fun/2
```

This was because the `local_characters` directory doesn't exist until a character is created. We didn't catch this in our tests because the create test for characters would happen before the list test. To fix this we updated `list_characters` to check the existence of the characters dir before attempting to access it (similar to how `list_local_systems` works).