### PR TITLE
Use `RELEASE_PAT` instead of `GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Configure git identity
         run: |


### PR DESCRIPTION
The repository has branch protections such that you can't merge to main without a PR (unless you are an admin / have the appropriate auth). The role associated with the `GITHUB_TOKEN` did not have such permissions. Thus instead we'll use a `RELEASE_PAT`.