### PR TITLE
Fix github and hex release jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,10 +157,13 @@ jobs:
           elixir-version: '1.19.5'
           otp-version: '28.3.1'
 
-      - name: Install Zig
-        uses: mlugg/setup-zig@v1
-        with:
-          version: 'latest'
+      - name: Install asdf
+        uses: asdf-vm/actions/setup@v3
+
+      - name: Install Zig via asdf
+        run: |
+          asdf plugin add zig https://github.com/asdf-community/asdf-zig.git
+          asdf install zig
 
       - name: Restore dependencies cache
         uses: actions/cache@v4


### PR DESCRIPTION
1. The hex release job was failing because mix deps were being run in the wrong directory
2. The `setup-zig` helper we were using was out of date