### PR TITLE
Fix the burrito build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,10 @@ jobs:
           otp-version: '28.3.1'
 
       - name: Install asdf
-        uses: asdf-vm/actions/setup@v3
+        run: |
+          go install github.com/asdf-vm/asdf/cmd/asdf@v0.18.0
+          echo "$HOME/go/bin" >> $GITHUB_PATH
+          echo "${ASDF_DATA_DIR:-$HOME/.asdf}/shims" >> $GITHUB_PATH
 
       - name: Install Zig via asdf
         run: |


### PR DESCRIPTION
Burrito builds were failing due to incorrect target specifications. Additionally, we were installing an out of date ASDF instance, and we've now resolved that.