### PR TITLE
Fix the github release to use proper lib version and bundle CLI binaries better

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,6 +181,24 @@ jobs:
       - name: Build Burrito binaries (all targets)
         run: MIX_ENV=prod mix release
 
+      - name: Package binaries for release
+        run: |
+          mkdir -p release_packages
+          for binary in burrito_out/ttrpg_dev_cli_*; do
+            name=$(basename "$binary")
+            target="${name#ttrpg_dev_cli_}"
+            if [[ "$target" == *windows* ]]; then
+              cp "$binary" "ttrpg-dev.exe"
+              zip "release_packages/${name}.zip" "ttrpg-dev.exe"
+              rm "ttrpg-dev.exe"
+            else
+              cp "$binary" "ttrpg-dev"
+              chmod +x "ttrpg-dev"
+              tar -czf "release_packages/${name}.tar.gz" "ttrpg-dev"
+              rm "ttrpg-dev"
+            fi
+          done
+
       - name: Create source archive
         run: |
           git archive \
@@ -195,5 +213,5 @@ jobs:
           tag_name: v${{ needs.version-bump.outputs.cli_version }}
           generate_release_notes: true
           files: |
-            burrito_out/*
+            release_packages/*
             ex_ttrpg_dev-*-source.tar.gz


### PR DESCRIPTION
If the CLI was bumped but not the library, the naming of the library included in the release would have the CLI version. We fixed this by ensuring the naming of the library bundle actually uses the version number of the library. Additionally all the CLI binaries had names specific to their target OS. This was good for differentiation, but bad for the actual name of the CLI (I don't want y'all to have to call `ex_ttrpg_cli_macos`). Instead the OS specific binaries are now zipped in a OS specific tar. The tar contains the OS specific CLI with the name `ttrpg-dev`.