### PR TITLE
feat: List characters by system

### DIFF
--- a/apps/ttrpg_dev_cli/lib/cli/characters.ex
+++ b/apps/ttrpg_dev_cli/lib/cli/characters.ex
@@ -44,7 +44,8 @@ defmodule ExTTRPGDev.CLI.Characters do
                 value_name: "SYSTEM",
                 help: "Show all characters belonging to specific system",
                 long: "--system",
-                required: false
+                required: false,
+                parser: &ExTTRPGDev.CLI.CustomParsers.system_parser(&1)
               ]
             ]
           ],


### PR DESCRIPTION
The CLI command `characters list` by default lists all the saved
characters. When one doesn't have many characters, that is not a
problem. However, when there is a significant number of saved characters
this becomes somewhat overwhelming. This commit adds the ability to
supply a `--system` option, allowing to list just the characters
belonging to a specific system.