### PR TITLE
Alias exit() to exit in the shell

### DIFF
--- a/apps/ttrpg_dev_cli/lib/cli/shell.ex
+++ b/apps/ttrpg_dev_cli/lib/cli/shell.ex
@@ -33,7 +33,7 @@ defmodule ExTTRPGDev.CLI.Shell do
 
   defp handle_input("", _optimus), do: :continue
 
-  defp handle_input(cmd, _optimus) when cmd in ["exit", "quit"], do: :exit
+  defp handle_input(cmd, _optimus) when cmd in ["exit", "quit", "exit()"], do: :exit
 
   defp handle_input("help", _optimus) do
     IO.puts("""


### PR DESCRIPTION
Adds `exit()` as an accepted alias for the `exit` command in the interactive shell, for users accustomed to the Python REPL (i.e. me. I keep typing `exit()` 🫠)