### PR TITLE
Add CLAUDE.md file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,8 @@ contributes = [{target = "type('id').field", value = 2}]
 - Functions return `{:ok, result}` / `{:error, reason}`; bang variants raise.
 - Tests use `async: true` and include doctests where appropriate.
 - Commits are small and atomic; messages explain *why*, not just what. Exceptions for large sweeping changes (lint rule changes, package updates, etc.).
+- Each commit should represent a single concern. Cleanup (typo fixes), abstraction (deduplicating logic), refactoring (reworking a function/module/system architecture), bug fixes, and feature additions must not be intermixed. If a feature requires cleanup, then a refactor, then the addition itself — those are three separate commits.
+- When working on a task, plan the commit sequence upfront. If you notice unrelated cleanup or duplication mid-task, defer it to a follow-up commit rather than mixing it into the current change. Use `git add -p` when needed to stage only the relevant hunks.
 - Commit descriptions are encouraged (but not required) and should cover: why the change is necessary, any foreseen issues, and paths intentionally not taken (and why).
 - Commits are GPG-signed (`commit.gpgsign=true`). Do not skip signing.
 - Do not add `Co-Authored-By` trailers.


### PR DESCRIPTION
It hasn't been an issue here, because I'm the only one working on this project thus far 🙈 But maybe, juuuust maybe, other people might like what this project is doing. If that happens, they might want to contribute themselves. For my day job, I see a lot of OSS community PRs which is very cool and very exciting. A fair number of those PRs of late have been partially to fully written by LLMs coding assistants. I am _not_ against this. However, I want to ensure that such PRs are easy to review and discuss. The `CLAUDE.md` should help with this. It should ensure that people who are using Claude as their agent end up with PRs and commits of a similar format when working on this project. One of the things most important to me in this document are the conventions around committing. Good commit hygiene makes code much easier to review, which in increases the likely stability of the library.

Of note, I would have _preferred_ an `AGENTS.md`, but I believe Claude does not support `AGENTS.md` at this time. 