### PR TITLE
Add saving throws to dnd_5e_srd rule system

### DIFF
--- a/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/roll/rolls.toml
+++ b/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/roll/rolls.toml
@@ -3,3 +3,9 @@ name = "Skill Check"
 dice = "1d20"
 target_type = "skill"
 bonus_field = "modifier"
+
+[roll.saving_throw]
+name = "Saving Throw"
+dice = "1d20"
+target_type = "saving_throw"
+bonus_field = "modifier"

--- a/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/saving_throw/saving_throws.toml
+++ b/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/saving_throw/saving_throws.toml
@@ -1,0 +1,29 @@
+[saving_throw.strength]
+name = "Strength"
+modifier.type = "accumulator"
+modifier.base = "ability('strength').modifier"
+
+[saving_throw.dexterity]
+name = "Dexterity"
+modifier.type = "accumulator"
+modifier.base = "ability('dexterity').modifier"
+
+[saving_throw.constitution]
+name = "Constitution"
+modifier.type = "accumulator"
+modifier.base = "ability('constitution').modifier"
+
+[saving_throw.wisdom]
+name = "Wisdom"
+modifier.type = "accumulator"
+modifier.base = "ability('wisdom').modifier"
+
+[saving_throw.intelligence]
+name = "Intelligence"
+modifier.type = "accumulator"
+modifier.base = "ability('intelligence').modifier"
+
+[saving_throw.charisma]
+name = "Charisma"
+modifier.type = "accumulator"
+modifier.base = "ability('charisma').modifier"

--- a/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/module.toml
+++ b/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/module.toml
@@ -33,3 +33,7 @@ name = "Equipment"
 [[concept_type]]
 id = "currency"
 name = "Currency"
+
+[[concept_type]]
+id = "saving_throw"
+name = "Saving Throw"

--- a/apps/ex_ttrpg_dev/test/rule_system/evaluator_test.exs
+++ b/apps/ex_ttrpg_dev/test/rule_system/evaluator_test.exs
@@ -99,5 +99,36 @@ defmodule ExTTRPGDev.RuleSystem.EvaluatorTest do
     assert resolved[{"skill", "athletics", "modifier"}] == 3
     assert resolved[{"skill", "acrobatics", "modifier"}] == 2
     assert resolved[{"skill", "arcana", "modifier"}] == 0
+
+    # Verify saving throws inherit their ability modifier
+    assert resolved[{"saving_throw", "strength", "modifier"}] == 3
+    assert resolved[{"saving_throw", "dexterity", "modifier"}] == 2
+    assert resolved[{"saving_throw", "constitution", "modifier"}] == 2
+    assert resolved[{"saving_throw", "wisdom", "modifier"}] == 1
+    assert resolved[{"saving_throw", "intelligence", "modifier"}] == 0
+    assert resolved[{"saving_throw", "charisma", "modifier"}] == -1
+  end
+
+  test "integration: saving throw modifier increases when proficiency is applied as an effect" do
+    {:ok, loader_data} = Loader.load(dnd_path())
+    {:ok, system} = Graph.build(loader_data)
+
+    generated = %{
+      {"ability", "strength", "base_score"} => 16,
+      {"ability", "dexterity", "base_score"} => 14,
+      {"ability", "constitution", "base_score"} => 14,
+      {"ability", "wisdom", "base_score"} => 12,
+      {"ability", "intelligence", "base_score"} => 10,
+      {"ability", "charisma", "base_score"} => 8
+    }
+
+    # Proficiency bonus of +2 applied to strength saving throw
+    effects = [%{target: {"saving_throw", "strength", "modifier"}, value: 2}]
+
+    assert {:ok, resolved} = Evaluator.evaluate(system, generated, effects)
+    # strength modifier is 3, plus proficiency bonus of 2
+    assert resolved[{"saving_throw", "strength", "modifier"}] == 5
+    # other saving throws are unaffected
+    assert resolved[{"saving_throw", "dexterity", "modifier"}] == 2
   end
 end

--- a/apps/ex_ttrpg_dev/test/rule_system/graph_test.exs
+++ b/apps/ex_ttrpg_dev/test/rule_system/graph_test.exs
@@ -92,8 +92,8 @@ defmodule ExTTRPGDev.RuleSystem.GraphTest do
     {:ok, loader_data} = Loader.load(dnd_path())
     assert {:ok, system} = Graph.build(loader_data)
 
-    # 6 attrs * 3 fields + 18 skills * 1 field = 36 nodes
-    assert map_size(system.nodes) == 36
+    # 6 attrs * 3 fields + 18 skills * 1 field + 6 saving throws * 1 field = 42 nodes
+    assert map_size(system.nodes) == 42
     # topological_order returns false if cyclic, a list if acyclic
     assert is_list(Graph.topological_order(system))
   end

--- a/apps/ex_ttrpg_dev/test/rule_system/loader_test.exs
+++ b/apps/ex_ttrpg_dev/test/rule_system/loader_test.exs
@@ -150,6 +150,45 @@ defmodule ExTTRPGDev.RuleSystem.LoaderTest do
     assert "currency" in concept_type_ids
   end
 
+  test "load/1 registers saving_throw concept type" do
+    {:ok, data} = Loader.load(dnd_path())
+
+    concept_type_ids = Enum.map(data.module.concept_types, & &1.id)
+    assert "saving_throw" in concept_type_ids
+  end
+
+  test "load/1 returns all six saving throw modifier nodes" do
+    {:ok, data} = Loader.load(dnd_path())
+    abilities = ~w(strength dexterity constitution wisdom intelligence charisma)
+
+    for ability <- abilities do
+      assert Map.has_key?(data.nodes, {"saving_throw", ability, "modifier"}),
+             "Missing modifier for saving_throw #{ability}"
+    end
+  end
+
+  test "load/1 saving throw modifier nodes are accumulators referencing the correct ability" do
+    {:ok, data} = Loader.load(dnd_path())
+
+    for ability <- ~w(strength dexterity constitution wisdom intelligence charisma) do
+      node = data.nodes[{"saving_throw", ability, "modifier"}]
+      assert %{type: :accumulator} = node
+      assert String.contains?(node.base, "ability('#{ability}').modifier")
+    end
+  end
+
+  test "load/1 returns saving_throw roll definition" do
+    {:ok, data} = Loader.load(dnd_path())
+
+    saving_throw_roll =
+      Enum.find_value(data.concept_metadata, fn {{type, _id}, meta} ->
+        if type == "roll" and meta["target_type"] == "saving_throw", do: meta
+      end)
+
+    assert saving_throw_roll["dice"] == "1d20"
+    assert saving_throw_roll["bonus_field"] == "modifier"
+  end
+
   test "load/1 returns all 5 currencies with correct conversion rates" do
     {:ok, data} = Loader.load(dnd_path())
     currency_meta = fn id -> data.concept_metadata[{"currency", id}] end

--- a/apps/ex_ttrpg_dev/test/rule_systems_test.exs
+++ b/apps/ex_ttrpg_dev/test/rule_systems_test.exs
@@ -56,7 +56,7 @@ defmodule ExTTRPGDevTest.RuleSystems do
 
   test "load_system!/1 returns LoadedSystem with nodes and rolling_methods" do
     system = RuleSystems.load_system!("dnd_5e_srd")
-    assert map_size(system.nodes) == 36
+    assert map_size(system.nodes) == 42
     assert Map.has_key?(system.rolling_methods, "standard")
   end
 end


### PR DESCRIPTION
Each of the six ability scores gets a corresponding saving throw concept with a modifier accumulator whose base is the ability's modifier. Using an accumulator (rather than a formula) means proficiency bonuses can be contributed as effects without any schema changes.

Also registers the saving_throw concept type in module.toml and adds a saving_throw roll definition (1d20 + modifier) so characters can roll saving throws via `characters roll <character> saving_throw <ability>`.