### PR TITLE
Add optional CodeScene delta check to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,12 @@ repos:
     pass_filenames: false
     files: mix\.lock$
 
+  - id: codescene
+    name: 'codescene: delta'
+    entry: sh -c 'if [ -z "$CS_ACCESS_TOKEN" ] || ! command -v cs > /dev/null 2>&1; then exit 0; fi; cs delta --git-hook --staged'
+    language: system
+    pass_filenames: false
+
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v1.4.0
   hooks:


### PR DESCRIPTION
Runs `cs delta --git-hook --staged` before each commit to surface code health regressions via CodeScene. The check is skipped gracefully when either the `CS_ACCESS_TOKEN` environment variable is unset or the `cs` binary is not installed, so contributors without a CodeScene account are not blocked.