### PR TITLE
Add initiative and passive perception to dnd_5e_srd

### DIFF
--- a/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/character_trait/character_traits.toml
+++ b/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/character_trait/character_traits.toml
@@ -50,3 +50,13 @@ amount.base = "0"
 name = "Darkvision"
 range.type = "accumulator"
 range.base = "0"
+
+[character_trait.initiative]
+name = "Initiative"
+bonus.type = "accumulator"
+bonus.base = "ability('dexterity').modifier"
+
+[character_trait.passive_perception]
+name = "Passive Perception"
+score.type = "accumulator"
+score.base = "10 + skill('perception').modifier"

--- a/apps/ex_ttrpg_dev/test/rule_system/graph_test.exs
+++ b/apps/ex_ttrpg_dev/test/rule_system/graph_test.exs
@@ -181,8 +181,8 @@ defmodule ExTTRPGDev.RuleSystem.GraphTest do
     {:ok, loader_data} = Loader.load(dnd_path())
     assert {:ok, system} = Graph.build(loader_data)
 
-    # 6 abilities * 3 fields + 18 skills * 1 field + 6 saving throws * 1 field + 6 character trait fields = 48 nodes
-    assert map_size(system.nodes) == 48
+    # 6 abilities * 3 fields + 18 skills * 1 field + 6 saving throws * 1 field + 8 character trait fields = 50 nodes
+    assert map_size(system.nodes) == 50
     # topological_order returns false if cyclic, a list if acyclic
     assert is_list(Graph.topological_order(system))
   end

--- a/apps/ex_ttrpg_dev/test/rule_systems_test.exs
+++ b/apps/ex_ttrpg_dev/test/rule_systems_test.exs
@@ -56,7 +56,7 @@ defmodule ExTTRPGDevTest.RuleSystems do
 
   test "load_system!/1 returns LoadedSystem with nodes and rolling_methods" do
     system = RuleSystems.load_system!("dnd_5e_srd")
-    assert map_size(system.nodes) == 48
+    assert map_size(system.nodes) == 50
     assert Map.has_key?(system.rolling_methods, "standard")
   end
 end


### PR DESCRIPTION
## Summary

- Adds `initiative.bonus` (accumulator, base = `ability('dexterity').modifier`)
- Adds `passive_perception.score` (accumulator, base = `10 + skill('perception').modifier`)

Both use accumulators rather than formulas so future effects (Alert feat, Observant feat) can contribute bonuses directly.

## Test plan

- [ ] `mix test` passes (node count assertions updated from 48 → 50)
- [ ] `character gen` on dnd_5e_srd shows initiative and passive perception in output