### PR TITLE
Add spellcasting stat nodes to dnd_5e_srd

### DIFF
--- a/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/character_trait/character_traits.toml
+++ b/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/character_trait/character_traits.toml
@@ -68,3 +68,16 @@ base.base = "10"
 dex_bonus.type = "accumulator"
 dex_bonus.base = "ability('dexterity').modifier"
 total.formula = "character_trait('armor_class').base + character_trait('armor_class').dex_bonus"
+
+[character_trait.spellcasting_ability_modifier]
+name = "Spellcasting Ability Modifier"
+value.type = "accumulator"
+value.base = "0"
+
+[character_trait.spell_save_dc]
+name = "Spell Save DC"
+score.formula = "8 + character_trait('proficiency_bonus').bonus + character_trait('spellcasting_ability_modifier').value"
+
+[character_trait.spell_attack_bonus]
+name = "Spell Attack Bonus"
+bonus.formula = "character_trait('proficiency_bonus').bonus + character_trait('spellcasting_ability_modifier').value"

--- a/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/class/bard.toml
+++ b/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/class/bard.toml
@@ -118,5 +118,9 @@ value = "ability('constitution').modifier + 8"
 target = "character_trait('max_hit_points').points"
 value = "ability('constitution').modifier * (character_trait('character_level').level - 1)"
 
+[[class.bard.contributes]]
+target = "character_trait('spellcasting_ability_modifier').value"
+value = "ability('charisma').modifier"
+
 [class.college_of_lore]
 name = "College of Lore"

--- a/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/class/cleric.toml
+++ b/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/class/cleric.toml
@@ -39,6 +39,10 @@ value = "ability('constitution').modifier + 8"
 target = "character_trait('max_hit_points').points"
 value = "ability('constitution').modifier * (character_trait('character_level').level - 1)"
 
+[[class.cleric.contributes]]
+target = "character_trait('spellcasting_ability_modifier').value"
+value = "ability('wisdom').modifier"
+
 [class.life_domain]
 name = "Life Domain"
 armor_proficiencies = ["heavy_armor"]

--- a/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/class/druid.toml
+++ b/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/class/druid.toml
@@ -58,5 +58,9 @@ value = "ability('constitution').modifier + 8"
 target = "character_trait('max_hit_points').points"
 value = "ability('constitution').modifier * (character_trait('character_level').level - 1)"
 
+[[class.druid.contributes]]
+target = "character_trait('spellcasting_ability_modifier').value"
+value = "ability('wisdom').modifier"
+
 [class.circle_of_the_land]
 name = "Circle of the Land"

--- a/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/class/paladin.toml
+++ b/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/class/paladin.toml
@@ -39,5 +39,9 @@ value = "ability('constitution').modifier + 10"
 target = "character_trait('max_hit_points').points"
 value = "ability('constitution').modifier * (character_trait('character_level').level - 1)"
 
+[[class.paladin.contributes]]
+target = "character_trait('spellcasting_ability_modifier').value"
+value = "ability('charisma').modifier"
+
 [class.oath_of_devotion]
 name = "Oath of Devotion"

--- a/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/class/ranger.toml
+++ b/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/class/ranger.toml
@@ -73,5 +73,9 @@ value = "ability('constitution').modifier + 10"
 target = "character_trait('max_hit_points').points"
 value = "ability('constitution').modifier * (character_trait('character_level').level - 1)"
 
+[[class.ranger.contributes]]
+target = "character_trait('spellcasting_ability_modifier').value"
+value = "ability('wisdom').modifier"
+
 [class.hunter]
 name = "Hunter"

--- a/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/class/sorcerer.toml
+++ b/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/class/sorcerer.toml
@@ -38,5 +38,9 @@ value = "ability('constitution').modifier + 6"
 target = "character_trait('max_hit_points').points"
 value = "ability('constitution').modifier * (character_trait('character_level').level - 1)"
 
+[[class.sorcerer.contributes]]
+target = "character_trait('spellcasting_ability_modifier').value"
+value = "ability('charisma').modifier"
+
 [class.draconic_bloodline]
 name = "Draconic Bloodline"

--- a/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/class/warlock.toml
+++ b/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/class/warlock.toml
@@ -55,5 +55,9 @@ value = "ability('constitution').modifier + 8"
 target = "character_trait('max_hit_points').points"
 value = "ability('constitution').modifier * (character_trait('character_level').level - 1)"
 
+[[class.warlock.contributes]]
+target = "character_trait('spellcasting_ability_modifier').value"
+value = "ability('charisma').modifier"
+
 [class.the_fiend]
 name = "The Fiend"

--- a/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/class/wizard.toml
+++ b/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/class/wizard.toml
@@ -38,5 +38,9 @@ value = "ability('constitution').modifier + 6"
 target = "character_trait('max_hit_points').points"
 value = "ability('constitution').modifier * (character_trait('character_level').level - 1)"
 
+[[class.wizard.contributes]]
+target = "character_trait('spellcasting_ability_modifier').value"
+value = "ability('intelligence').modifier"
+
 [class.school_of_evocation]
 name = "School of Evocation"

--- a/apps/ex_ttrpg_dev/test/rule_system/evaluator_test.exs
+++ b/apps/ex_ttrpg_dev/test/rule_system/evaluator_test.exs
@@ -266,7 +266,7 @@ defmodule ExTTRPGDev.RuleSystem.EvaluatorTest do
   end
 
   describe "integration" do
-    test "evaluate full dnd_5e_srd with known scores" do
+    setup do
       {:ok, loader_data} = Loader.load(dnd_path())
       {:ok, system} = Graph.build(loader_data)
 
@@ -279,53 +279,49 @@ defmodule ExTTRPGDev.RuleSystem.EvaluatorTest do
         {"ability", "charisma", "base_score"} => 8
       }
 
-      assert {:ok, resolved} = Evaluator.evaluate(system, generated)
+      {:ok, resolved} = Evaluator.evaluate(system, generated)
+      %{system: system, generated: generated, resolved: resolved}
+    end
 
-      # Verify modifiers: floor((score - 10) / 2)
+    test "physical ability modifiers are calculated correctly", %{resolved: resolved} do
       assert resolved[{"ability", "strength", "modifier"}] == 3
       assert resolved[{"ability", "dexterity", "modifier"}] == 2
       assert resolved[{"ability", "constitution", "modifier"}] == 2
+    end
+
+    test "mental ability modifiers are calculated correctly", %{resolved: resolved} do
       assert resolved[{"ability", "wisdom", "modifier"}] == 1
       assert resolved[{"ability", "intelligence", "modifier"}] == 0
       assert resolved[{"ability", "charisma", "modifier"}] == -1
+    end
 
-      # Verify skills inherit their ability modifier
+    test "skills default to their governing ability modifier", %{resolved: resolved} do
       assert resolved[{"skill", "athletics", "modifier"}] == 3
       assert resolved[{"skill", "acrobatics", "modifier"}] == 2
       assert resolved[{"skill", "arcana", "modifier"}] == 0
+    end
 
-      # Verify proficiency bonus base value
+    test "proficiency bonus base value is 2 at level 1", %{resolved: resolved} do
       assert resolved[{"character_trait", "proficiency_bonus", "bonus"}] == 2
+    end
 
-      # Verify saving throws inherit their ability modifier
+    test "physical saving throws inherit ability modifier", %{resolved: resolved} do
       assert resolved[{"saving_throw", "strength", "modifier"}] == 3
       assert resolved[{"saving_throw", "dexterity", "modifier"}] == 2
       assert resolved[{"saving_throw", "constitution", "modifier"}] == 2
+    end
+
+    test "mental saving throws inherit ability modifier", %{resolved: resolved} do
       assert resolved[{"saving_throw", "wisdom", "modifier"}] == 1
       assert resolved[{"saving_throw", "intelligence", "modifier"}] == 0
       assert resolved[{"saving_throw", "charisma", "modifier"}] == -1
     end
 
-    test "saving throw modifier increases when proficiency is applied as an effect" do
-      {:ok, loader_data} = Loader.load(dnd_path())
-      {:ok, system} = Graph.build(loader_data)
-
-      generated = %{
-        {"ability", "strength", "base_score"} => 16,
-        {"ability", "dexterity", "base_score"} => 14,
-        {"ability", "constitution", "base_score"} => 14,
-        {"ability", "wisdom", "base_score"} => 12,
-        {"ability", "intelligence", "base_score"} => 10,
-        {"ability", "charisma", "base_score"} => 8
-      }
-
-      # Proficiency bonus of +2 applied to strength saving throw
+    test "saving throw modifier increases when proficiency is applied as an effect",
+         %{system: system, generated: generated} do
       effects = [%{target: {"saving_throw", "strength", "modifier"}, value: 2}]
-
       assert {:ok, resolved} = Evaluator.evaluate(system, generated, effects)
-      # strength modifier is 3, plus proficiency bonus of 2
       assert resolved[{"saving_throw", "strength", "modifier"}] == 5
-      # other saving throws are unaffected
       assert resolved[{"saving_throw", "dexterity", "modifier"}] == 2
     end
   end
@@ -415,6 +411,70 @@ defmodule ExTTRPGDev.RuleSystem.EvaluatorTest do
       effects = item_effects(system, "plate", false)
       assert {:ok, resolved} = Evaluator.evaluate(system, generated, effects)
       assert resolved[{"character_trait", "armor_class", "total"}] == 12
+    end
+  end
+
+  describe "spellcasting stat nodes integration" do
+    setup do
+      {:ok, loader_data} = Loader.load(dnd_path())
+      {:ok, system} = Graph.build(loader_data)
+
+      generated = %{
+        {"ability", "strength", "base_score"} => 10,
+        {"ability", "dexterity", "base_score"} => 10,
+        {"ability", "constitution", "base_score"} => 10,
+        {"ability", "wisdom", "base_score"} => 16,
+        {"ability", "intelligence", "base_score"} => 14,
+        {"ability", "charisma", "base_score"} => 12
+      }
+
+      # WIS mod = +3, INT mod = +2, CHA mod = +1, proficiency bonus = +2
+
+      %{system: system, generated: generated}
+    end
+
+    defp class_effects(system, class_id) do
+      Enum.filter(system.effects, fn
+        %{source: {"class", id}} -> id == class_id
+        _ -> false
+      end)
+    end
+
+    test "non-spellcaster: spellcasting_ability_modifier is 0, dc and bonus still resolve",
+         %{system: system, generated: generated} do
+      # Fighter has no spellcasting contribution
+      effects = class_effects(system, "fighter")
+      assert {:ok, resolved} = Evaluator.evaluate(system, generated, effects)
+      assert resolved[{"character_trait", "spellcasting_ability_modifier", "value"}] == 0
+      assert resolved[{"character_trait", "spell_save_dc", "score"}] == 10
+      assert resolved[{"character_trait", "spell_attack_bonus", "bonus"}] == 2
+    end
+
+    test "wizard uses Intelligence", %{system: system, generated: generated} do
+      effects = class_effects(system, "wizard")
+      assert {:ok, resolved} = Evaluator.evaluate(system, generated, effects)
+      # INT mod = +2; DC = 8 + 2 + 2 = 12; attack = 2 + 2 = 4
+      assert resolved[{"character_trait", "spellcasting_ability_modifier", "value"}] == 2
+      assert resolved[{"character_trait", "spell_save_dc", "score"}] == 12
+      assert resolved[{"character_trait", "spell_attack_bonus", "bonus"}] == 4
+    end
+
+    test "cleric uses Wisdom", %{system: system, generated: generated} do
+      effects = class_effects(system, "cleric")
+      assert {:ok, resolved} = Evaluator.evaluate(system, generated, effects)
+      # WIS mod = +3; DC = 8 + 2 + 3 = 13; attack = 2 + 3 = 5
+      assert resolved[{"character_trait", "spellcasting_ability_modifier", "value"}] == 3
+      assert resolved[{"character_trait", "spell_save_dc", "score"}] == 13
+      assert resolved[{"character_trait", "spell_attack_bonus", "bonus"}] == 5
+    end
+
+    test "bard uses Charisma", %{system: system, generated: generated} do
+      effects = class_effects(system, "bard")
+      assert {:ok, resolved} = Evaluator.evaluate(system, generated, effects)
+      # CHA mod = +1; DC = 8 + 2 + 1 = 11; attack = 2 + 1 = 3
+      assert resolved[{"character_trait", "spellcasting_ability_modifier", "value"}] == 1
+      assert resolved[{"character_trait", "spell_save_dc", "score"}] == 11
+      assert resolved[{"character_trait", "spell_attack_bonus", "bonus"}] == 3
     end
   end
 

--- a/apps/ex_ttrpg_dev/test/rule_system/graph_test.exs
+++ b/apps/ex_ttrpg_dev/test/rule_system/graph_test.exs
@@ -181,8 +181,8 @@ defmodule ExTTRPGDev.RuleSystem.GraphTest do
     {:ok, loader_data} = Loader.load(dnd_path())
     assert {:ok, system} = Graph.build(loader_data)
 
-    # 6 abilities * 3 fields + 18 skills * 1 field + 6 saving throws * 1 field + 11 character trait fields = 53 nodes
-    assert map_size(system.nodes) == 53
+    # 6 abilities * 3 fields + 18 skills * 1 field + 6 saving throws * 1 field + 14 character trait fields = 56 nodes
+    assert map_size(system.nodes) == 56
     # topological_order returns false if cyclic, a list if acyclic
     assert is_list(Graph.topological_order(system))
   end

--- a/apps/ex_ttrpg_dev/test/rule_systems_test.exs
+++ b/apps/ex_ttrpg_dev/test/rule_systems_test.exs
@@ -56,7 +56,7 @@ defmodule ExTTRPGDevTest.RuleSystems do
 
   test "load_system!/1 returns LoadedSystem with nodes and rolling_methods" do
     system = RuleSystems.load_system!("dnd_5e_srd")
-    assert map_size(system.nodes) == 53
+    assert map_size(system.nodes) == 56
     assert Map.has_key?(system.rolling_methods, "standard")
   end
 end


### PR DESCRIPTION
## Summary

- Adds `spellcasting_ability_modifier.value` (accumulator, base 0) — each spellcasting class contributes its casting ability as an active effect: INT (wizard), WIS (cleric, druid, ranger), CHA (bard, paladin, sorcerer, warlock)
- Adds `spell_save_dc.score` (formula: `8 + proficiency_bonus + spellcasting_ability_modifier`)
- Adds `spell_attack_bonus.bonus` (formula: `proficiency_bonus + spellcasting_ability_modifier`)

Non-spellcasters (barbarian, fighter, monk, rogue) contribute nothing — their modifier stays 0 and the nodes still resolve, which is correct since they have no spells.

Also splits a large monolithic integration test into focused per-concern tests to stay within CodeScene's assertion block threshold.

## Test plan

- [x] `mix test` passes
- [x] Wizard character shows correct spell save DC (8 + prof + INT mod)
- [x] Cleric character shows correct spell save DC (8 + prof + WIS mod)
- [x] Fighter character: spellcasting_ability_modifier = 0