### PR TITLE
feat(dnd_5e_srd): add SRD spell catalog definitions

### DIFF
--- a/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/spell/cantrips.toml
+++ b/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/spell/cantrips.toml
@@ -1,0 +1,363 @@
+[spell.acid_splash]
+name = "Acid Splash"
+level = 0
+school = "conjuration"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.blade_ward]
+name = "Blade Ward"
+level = 0
+school = "abjuration"
+casting_time = "1 action"
+range = "Self"
+duration = "1 round"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["bard", "sorcerer", "warlock", "wizard"]
+
+[spell.chill_touch]
+name = "Chill Touch"
+level = 0
+school = "necromancy"
+casting_time = "1 action"
+range = "120 feet"
+duration = "1 round"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["sorcerer", "warlock", "wizard"]
+
+[spell.dancing_lights]
+name = "Dancing Lights"
+level = 0
+school = "evocation"
+casting_time = "1 action"
+range = "120 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["bard", "sorcerer", "wizard"]
+
+[spell.druidcraft]
+name = "Druidcraft"
+level = 0
+school = "transmutation"
+casting_time = "1 action"
+range = "30 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["druid"]
+
+[spell.eldritch_blast]
+name = "Eldritch Blast"
+level = 0
+school = "evocation"
+casting_time = "1 action"
+range = "120 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["warlock"]
+
+[spell.fire_bolt]
+name = "Fire Bolt"
+level = 0
+school = "evocation"
+casting_time = "1 action"
+range = "120 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.friends]
+name = "Friends"
+level = 0
+school = "enchantment"
+casting_time = "1 action"
+range = "Self"
+duration = "Concentration, up to 1 minute"
+verbal = false
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["bard", "sorcerer", "warlock", "wizard"]
+
+[spell.guidance]
+name = "Guidance"
+level = 0
+school = "divination"
+casting_time = "1 action"
+range = "Touch"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["cleric", "druid"]
+
+[spell.light]
+name = "Light"
+level = 0
+school = "evocation"
+casting_time = "1 action"
+range = "Touch"
+duration = "1 hour"
+verbal = true
+somatic = false
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "cleric", "sorcerer", "wizard"]
+
+[spell.mage_hand]
+name = "Mage Hand"
+level = 0
+school = "conjuration"
+casting_time = "1 action"
+range = "30 feet"
+duration = "1 minute"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["bard", "sorcerer", "warlock", "wizard"]
+
+[spell.mending]
+name = "Mending"
+level = 0
+school = "transmutation"
+casting_time = "1 minute"
+range = "Touch"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "cleric", "druid", "sorcerer", "wizard"]
+
+[spell.message]
+name = "Message"
+level = 0
+school = "transmutation"
+casting_time = "1 action"
+range = "120 feet"
+duration = "1 round"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "sorcerer", "wizard"]
+
+[spell.minor_illusion]
+name = "Minor Illusion"
+level = 0
+school = "illusion"
+casting_time = "1 action"
+range = "30 feet"
+duration = "1 minute"
+verbal = false
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "sorcerer", "warlock", "wizard"]
+
+[spell.poison_spray]
+name = "Poison Spray"
+level = 0
+school = "conjuration"
+casting_time = "1 action"
+range = "10 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["druid", "sorcerer", "warlock", "wizard"]
+
+[spell.prestidigitation]
+name = "Prestidigitation"
+level = 0
+school = "transmutation"
+casting_time = "1 action"
+range = "10 feet"
+duration = "Up to 1 hour"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["bard", "sorcerer", "warlock", "wizard"]
+
+[spell.produce_flame]
+name = "Produce Flame"
+level = 0
+school = "conjuration"
+casting_time = "1 action"
+range = "Self"
+duration = "10 minutes"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["druid"]
+
+[spell.ray_of_frost]
+name = "Ray of Frost"
+level = 0
+school = "evocation"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.resistance]
+name = "Resistance"
+level = 0
+school = "abjuration"
+casting_time = "1 action"
+range = "Touch"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["cleric", "druid"]
+
+[spell.sacred_flame]
+name = "Sacred Flame"
+level = 0
+school = "evocation"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["cleric"]
+
+[spell.shillelagh]
+name = "Shillelagh"
+level = 0
+school = "transmutation"
+casting_time = "1 bonus action"
+range = "Touch"
+duration = "1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["druid"]
+
+[spell.shocking_grasp]
+name = "Shocking Grasp"
+level = 0
+school = "evocation"
+casting_time = "1 action"
+range = "Touch"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.spare_the_dying]
+name = "Spare the Dying"
+level = 0
+school = "necromancy"
+casting_time = "1 action"
+range = "Touch"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["cleric"]
+
+[spell.thaumaturgy]
+name = "Thaumaturgy"
+level = 0
+school = "transmutation"
+casting_time = "1 action"
+range = "30 feet"
+duration = "Up to 1 minute"
+verbal = true
+somatic = false
+material = false
+concentration = false
+ritual = false
+classes = ["cleric"]
+
+[spell.true_strike]
+name = "True Strike"
+level = 0
+school = "divination"
+casting_time = "1 action"
+range = "30 feet"
+duration = "Concentration, up to 1 round"
+verbal = false
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["bard", "sorcerer", "warlock", "wizard"]
+
+[spell.vicious_mockery]
+name = "Vicious Mockery"
+level = 0
+school = "enchantment"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = false
+material = false
+concentration = false
+ritual = false
+classes = ["bard"]

--- a/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/spell/level_1.toml
+++ b/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/spell/level_1.toml
@@ -1,0 +1,686 @@
+[spell.alarm]
+name = "Alarm"
+level = 1
+school = "abjuration"
+casting_time = "1 minute"
+range = "30 feet"
+duration = "8 hours"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = true
+classes = ["ranger", "wizard"]
+
+[spell.animal_friendship]
+name = "Animal Friendship"
+level = 1
+school = "enchantment"
+casting_time = "1 action"
+range = "30 feet"
+duration = "24 hours"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "druid", "ranger"]
+
+[spell.bane]
+name = "Bane"
+level = 1
+school = "enchantment"
+casting_time = "1 action"
+range = "30 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["bard", "cleric"]
+
+[spell.bless]
+name = "Bless"
+level = 1
+school = "enchantment"
+casting_time = "1 action"
+range = "30 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["cleric", "paladin"]
+
+[spell.burning_hands]
+name = "Burning Hands"
+level = 1
+school = "evocation"
+casting_time = "1 action"
+range = "Self (15-foot cone)"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.charm_person]
+name = "Charm Person"
+level = 1
+school = "enchantment"
+casting_time = "1 action"
+range = "30 feet"
+duration = "1 hour"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["bard", "druid", "sorcerer", "warlock", "wizard"]
+
+[spell.color_spray]
+name = "Color Spray"
+level = 1
+school = "illusion"
+casting_time = "1 action"
+range = "Self (15-foot cone)"
+duration = "1 round"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.command]
+name = "Command"
+level = 1
+school = "enchantment"
+casting_time = "1 action"
+range = "60 feet"
+duration = "1 round"
+verbal = true
+somatic = false
+material = false
+concentration = false
+ritual = false
+classes = ["cleric", "paladin"]
+
+[spell.comprehend_languages]
+name = "Comprehend Languages"
+level = 1
+school = "divination"
+casting_time = "1 action"
+range = "Self"
+duration = "1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = true
+classes = ["bard", "sorcerer", "warlock", "wizard"]
+
+[spell.create_or_destroy_water]
+name = "Create or Destroy Water"
+level = 1
+school = "transmutation"
+casting_time = "1 action"
+range = "30 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["cleric", "druid"]
+
+[spell.cure_wounds]
+name = "Cure Wounds"
+level = 1
+school = "evocation"
+casting_time = "1 action"
+range = "Touch"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["bard", "cleric", "druid", "paladin", "ranger"]
+
+[spell.detect_evil_and_good]
+name = "Detect Evil and Good"
+level = 1
+school = "divination"
+casting_time = "1 action"
+range = "Self"
+duration = "Concentration, up to 10 minutes"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["cleric", "paladin"]
+
+[spell.detect_magic]
+name = "Detect Magic"
+level = 1
+school = "divination"
+casting_time = "1 action"
+range = "Self"
+duration = "Concentration, up to 10 minutes"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = true
+classes = ["bard", "cleric", "druid", "paladin", "ranger", "sorcerer", "wizard"]
+
+[spell.detect_poison_and_disease]
+name = "Detect Poison and Disease"
+level = 1
+school = "divination"
+casting_time = "1 action"
+range = "Self"
+duration = "Concentration, up to 10 minutes"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = true
+classes = ["cleric", "druid", "paladin", "ranger"]
+
+[spell.disguise_self]
+name = "Disguise Self"
+level = 1
+school = "illusion"
+casting_time = "1 action"
+range = "Self"
+duration = "1 hour"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["bard", "sorcerer", "wizard"]
+
+[spell.divine_favor]
+name = "Divine Favor"
+level = 1
+school = "evocation"
+casting_time = "1 bonus action"
+range = "Self"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["paladin"]
+
+[spell.entangle]
+name = "Entangle"
+level = 1
+school = "conjuration"
+casting_time = "1 action"
+range = "90 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["druid"]
+
+[spell.expeditious_retreat]
+name = "Expeditious Retreat"
+level = 1
+school = "transmutation"
+casting_time = "1 bonus action"
+range = "Self"
+duration = "Concentration, up to 10 minutes"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["sorcerer", "warlock", "wizard"]
+
+[spell.faerie_fire]
+name = "Faerie Fire"
+level = 1
+school = "evocation"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = false
+material = false
+concentration = true
+ritual = false
+classes = ["bard", "druid"]
+
+[spell.false_life]
+name = "False Life"
+level = 1
+school = "necromancy"
+casting_time = "1 action"
+range = "Self"
+duration = "1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.feather_fall]
+name = "Feather Fall"
+level = 1
+school = "transmutation"
+casting_time = "1 reaction"
+range = "60 feet"
+duration = "1 minute"
+verbal = true
+somatic = false
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "sorcerer", "wizard"]
+
+[spell.find_familiar]
+name = "Find Familiar"
+level = 1
+school = "conjuration"
+casting_time = "1 hour"
+range = "10 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = true
+classes = ["wizard"]
+
+[spell.fog_cloud]
+name = "Fog Cloud"
+level = 1
+school = "conjuration"
+casting_time = "1 action"
+range = "120 feet"
+duration = "Concentration, up to 1 hour"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["druid", "ranger", "sorcerer", "wizard"]
+
+[spell.goodberry]
+name = "Goodberry"
+level = 1
+school = "transmutation"
+casting_time = "1 action"
+range = "Touch"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["druid", "ranger"]
+
+[spell.grease]
+name = "Grease"
+level = 1
+school = "conjuration"
+casting_time = "1 action"
+range = "60 feet"
+duration = "1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["wizard"]
+
+[spell.guiding_bolt]
+name = "Guiding Bolt"
+level = 1
+school = "evocation"
+casting_time = "1 action"
+range = "120 feet"
+duration = "1 round"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["cleric"]
+
+[spell.healing_word]
+name = "Healing Word"
+level = 1
+school = "evocation"
+casting_time = "1 bonus action"
+range = "60 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = false
+material = false
+concentration = false
+ritual = false
+classes = ["bard", "cleric", "druid"]
+
+[spell.hellish_rebuke]
+name = "Hellish Rebuke"
+level = 1
+school = "evocation"
+casting_time = "1 reaction"
+range = "60 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["warlock"]
+
+[spell.heroism]
+name = "Heroism"
+level = 1
+school = "enchantment"
+casting_time = "1 action"
+range = "Touch"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["bard", "paladin"]
+
+[spell.hideous_laughter]
+name = "Hideous Laughter"
+level = 1
+school = "enchantment"
+casting_time = "1 action"
+range = "30 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["bard", "wizard"]
+
+[spell.hunters_mark]
+name = "Hunter's Mark"
+level = 1
+school = "divination"
+casting_time = "1 bonus action"
+range = "90 feet"
+duration = "Concentration, up to 1 hour"
+verbal = true
+somatic = false
+material = false
+concentration = true
+ritual = false
+classes = ["ranger"]
+
+[spell.identify]
+name = "Identify"
+level = 1
+school = "divination"
+casting_time = "1 minute"
+range = "Touch"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = true
+classes = ["bard", "wizard"]
+
+[spell.illusory_script]
+name = "Illusory Script"
+level = 1
+school = "illusion"
+casting_time = "1 minute"
+range = "Touch"
+duration = "10 days"
+verbal = false
+somatic = true
+material = true
+concentration = false
+ritual = true
+classes = ["bard", "warlock", "wizard"]
+
+[spell.inflict_wounds]
+name = "Inflict Wounds"
+level = 1
+school = "necromancy"
+casting_time = "1 action"
+range = "Touch"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["cleric"]
+
+[spell.jump]
+name = "Jump"
+level = 1
+school = "transmutation"
+casting_time = "1 action"
+range = "Touch"
+duration = "1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["druid", "ranger", "sorcerer", "wizard"]
+
+[spell.longstrider]
+name = "Longstrider"
+level = 1
+school = "transmutation"
+casting_time = "1 action"
+range = "Touch"
+duration = "1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "druid", "ranger", "wizard"]
+
+[spell.mage_armor]
+name = "Mage Armor"
+level = 1
+school = "abjuration"
+casting_time = "1 action"
+range = "Touch"
+duration = "8 hours"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.magic_missile]
+name = "Magic Missile"
+level = 1
+school = "evocation"
+casting_time = "1 action"
+range = "120 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.protection_from_evil_and_good]
+name = "Protection from Evil and Good"
+level = 1
+school = "abjuration"
+casting_time = "1 action"
+range = "Touch"
+duration = "Concentration, up to 10 minutes"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["cleric", "druid", "paladin", "warlock", "wizard"]
+
+[spell.purify_food_and_drink]
+name = "Purify Food and Drink"
+level = 1
+school = "transmutation"
+casting_time = "1 action"
+range = "10 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = true
+classes = ["cleric", "druid", "paladin"]
+
+[spell.shield]
+name = "Shield"
+level = 1
+school = "abjuration"
+casting_time = "1 reaction"
+range = "Self"
+duration = "1 round"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.shield_of_faith]
+name = "Shield of Faith"
+level = 1
+school = "abjuration"
+casting_time = "1 bonus action"
+range = "60 feet"
+duration = "Concentration, up to 10 minutes"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["cleric", "paladin"]
+
+[spell.silent_image]
+name = "Silent Image"
+level = 1
+school = "illusion"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Concentration, up to 10 minutes"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["bard", "sorcerer", "wizard"]
+
+[spell.sleep]
+name = "Sleep"
+level = 1
+school = "enchantment"
+casting_time = "1 action"
+range = "90 feet"
+duration = "1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "sorcerer", "wizard"]
+
+[spell.speak_with_animals]
+name = "Speak with Animals"
+level = 1
+school = "divination"
+casting_time = "1 action"
+range = "Self"
+duration = "10 minutes"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = true
+classes = ["bard", "druid", "ranger"]
+
+[spell.thunderwave]
+name = "Thunderwave"
+level = 1
+school = "evocation"
+casting_time = "1 action"
+range = "Self (15-foot cube)"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["bard", "druid", "sorcerer", "wizard"]
+
+[spell.unseen_servant]
+name = "Unseen Servant"
+level = 1
+school = "conjuration"
+casting_time = "1 action"
+range = "60 feet"
+duration = "1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = true
+classes = ["bard", "warlock", "wizard"]
+
+
+[spell.floating_disk]
+name = "Floating Disk"
+level = 1
+school = "conjuration"
+casting_time = "1 action"
+range = "30 feet"
+duration = "1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = true
+classes = ["wizard"]
+
+[spell.sanctuary]
+name = "Sanctuary"
+level = 1
+school = "abjuration"
+casting_time = "1 bonus action"
+range = "30 feet"
+duration = "1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["cleric"]

--- a/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/spell/level_2.toml
+++ b/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/spell/level_2.toml
@@ -1,0 +1,769 @@
+[spell.aid]
+name = "Aid"
+level = 2
+school = "abjuration"
+casting_time = "1 action"
+range = "30 feet"
+duration = "8 hours"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["cleric", "paladin"]
+
+[spell.alter_self]
+name = "Alter Self"
+level = 2
+school = "transmutation"
+casting_time = "1 action"
+range = "Self"
+duration = "Concentration, up to 1 hour"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.animal_messenger]
+name = "Animal Messenger"
+level = 2
+school = "enchantment"
+casting_time = "1 action"
+range = "30 feet"
+duration = "24 hours"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = true
+classes = ["bard", "druid", "ranger"]
+
+[spell.arcane_lock]
+name = "Arcane Lock"
+level = 2
+school = "abjuration"
+casting_time = "1 action"
+range = "Touch"
+duration = "Until dispelled"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["wizard"]
+
+[spell.augury]
+name = "Augury"
+level = 2
+school = "divination"
+casting_time = "1 minute"
+range = "Self"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = true
+classes = ["cleric"]
+
+[spell.barkskin]
+name = "Barkskin"
+level = 2
+school = "transmutation"
+casting_time = "1 action"
+range = "Touch"
+duration = "Concentration, up to 1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["druid", "ranger"]
+
+[spell.beast_sense]
+name = "Beast Sense"
+level = 2
+school = "divination"
+casting_time = "1 action"
+range = "Touch"
+duration = "Concentration, up to 1 hour"
+verbal = false
+somatic = true
+material = false
+concentration = true
+ritual = true
+classes = ["druid", "ranger"]
+
+[spell.blindness_deafness]
+name = "Blindness/Deafness"
+level = 2
+school = "necromancy"
+casting_time = "1 action"
+range = "30 feet"
+duration = "1 minute"
+verbal = true
+somatic = false
+material = false
+concentration = false
+ritual = false
+classes = ["bard", "cleric", "sorcerer", "wizard"]
+
+[spell.blur]
+name = "Blur"
+level = 2
+school = "illusion"
+casting_time = "1 action"
+range = "Self"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = false
+material = false
+concentration = true
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.branding_smite]
+name = "Branding Smite"
+level = 2
+school = "evocation"
+casting_time = "1 bonus action"
+range = "Self"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = false
+material = false
+concentration = true
+ritual = false
+classes = ["paladin"]
+
+[spell.calm_emotions]
+name = "Calm Emotions"
+level = 2
+school = "enchantment"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["bard", "cleric"]
+
+[spell.continual_flame]
+name = "Continual Flame"
+level = 2
+school = "evocation"
+casting_time = "1 action"
+range = "Touch"
+duration = "Until dispelled"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["cleric", "wizard"]
+
+[spell.darkness]
+name = "Darkness"
+level = 2
+school = "evocation"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Concentration, up to 10 minutes"
+verbal = true
+somatic = false
+material = true
+concentration = true
+ritual = false
+classes = ["sorcerer", "warlock", "wizard"]
+
+[spell.darkvision]
+name = "Darkvision"
+level = 2
+school = "transmutation"
+casting_time = "1 action"
+range = "Touch"
+duration = "8 hours"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["druid", "ranger", "sorcerer", "wizard"]
+
+[spell.detect_thoughts]
+name = "Detect Thoughts"
+level = 2
+school = "divination"
+casting_time = "1 action"
+range = "Self"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["bard", "sorcerer", "wizard"]
+
+[spell.enhance_ability]
+name = "Enhance Ability"
+level = 2
+school = "transmutation"
+casting_time = "1 action"
+range = "Touch"
+duration = "Concentration, up to 1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["bard", "cleric", "druid", "sorcerer"]
+
+[spell.enlarge_reduce]
+name = "Enlarge/Reduce"
+level = 2
+school = "transmutation"
+casting_time = "1 action"
+range = "30 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.enthrall]
+name = "Enthrall"
+level = 2
+school = "enchantment"
+casting_time = "1 action"
+range = "60 feet"
+duration = "1 minute"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["bard", "warlock"]
+
+[spell.find_steed]
+name = "Find Steed"
+level = 2
+school = "conjuration"
+casting_time = "10 minutes"
+range = "30 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["paladin"]
+
+[spell.find_traps]
+name = "Find Traps"
+level = 2
+school = "divination"
+casting_time = "1 action"
+range = "120 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["cleric", "druid", "ranger"]
+
+[spell.flame_blade]
+name = "Flame Blade"
+level = 2
+school = "evocation"
+casting_time = "1 bonus action"
+range = "Self"
+duration = "Concentration, up to 10 minutes"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["druid"]
+
+[spell.flaming_sphere]
+name = "Flaming Sphere"
+level = 2
+school = "conjuration"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["druid", "wizard"]
+
+[spell.gentle_repose]
+name = "Gentle Repose"
+level = 2
+school = "necromancy"
+casting_time = "1 action"
+range = "Touch"
+duration = "10 days"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = true
+classes = ["cleric", "wizard"]
+
+[spell.gust_of_wind]
+name = "Gust of Wind"
+level = 2
+school = "evocation"
+casting_time = "1 action"
+range = "Self (60-foot line)"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["druid", "sorcerer", "wizard"]
+
+[spell.heat_metal]
+name = "Heat Metal"
+level = 2
+school = "transmutation"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["bard", "druid"]
+
+[spell.hold_person]
+name = "Hold Person"
+level = 2
+school = "enchantment"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["bard", "cleric", "druid", "sorcerer", "warlock", "wizard"]
+
+[spell.invisibility]
+name = "Invisibility"
+level = 2
+school = "illusion"
+casting_time = "1 action"
+range = "Touch"
+duration = "Concentration, up to 1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["bard", "sorcerer", "warlock", "wizard"]
+
+[spell.knock]
+name = "Knock"
+level = 2
+school = "transmutation"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = false
+material = false
+concentration = false
+ritual = false
+classes = ["bard", "sorcerer", "wizard"]
+
+[spell.lesser_restoration]
+name = "Lesser Restoration"
+level = 2
+school = "abjuration"
+casting_time = "1 action"
+range = "Touch"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["bard", "cleric", "druid", "paladin", "ranger"]
+
+[spell.levitate]
+name = "Levitate"
+level = 2
+school = "transmutation"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Concentration, up to 10 minutes"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.locate_animals_or_plants]
+name = "Locate Animals or Plants"
+level = 2
+school = "divination"
+casting_time = "1 action"
+range = "Self"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = true
+classes = ["bard", "druid", "ranger"]
+
+[spell.locate_object]
+name = "Locate Object"
+level = 2
+school = "divination"
+casting_time = "1 action"
+range = "Self"
+duration = "Concentration, up to 10 minutes"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["bard", "cleric", "druid", "paladin", "ranger", "wizard"]
+
+[spell.magic_mouth]
+name = "Magic Mouth"
+level = 2
+school = "illusion"
+casting_time = "1 minute"
+range = "30 feet"
+duration = "Until dispelled"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = true
+classes = ["bard", "wizard"]
+
+[spell.magic_weapon]
+name = "Magic Weapon"
+level = 2
+school = "transmutation"
+casting_time = "1 bonus action"
+range = "Touch"
+duration = "Concentration, up to 1 hour"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["paladin", "wizard"]
+
+[spell.misty_step]
+name = "Misty Step"
+level = 2
+school = "conjuration"
+casting_time = "1 bonus action"
+range = "Self"
+duration = "Instantaneous"
+verbal = true
+somatic = false
+material = false
+concentration = false
+ritual = false
+classes = ["sorcerer", "warlock", "wizard"]
+
+[spell.moonbeam]
+name = "Moonbeam"
+level = 2
+school = "evocation"
+casting_time = "1 action"
+range = "120 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["druid"]
+
+[spell.arcanists_magic_aura]
+name = "Arcanist's Magic Aura"
+level = 2
+school = "illusion"
+casting_time = "1 action"
+range = "Touch"
+duration = "24 hours"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["wizard"]
+
+[spell.pass_without_trace]
+name = "Pass without Trace"
+level = 2
+school = "abjuration"
+casting_time = "1 action"
+range = "Self"
+duration = "Concentration, up to 1 hour"
+verbal = false
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["druid", "ranger"]
+
+[spell.prayer_of_healing]
+name = "Prayer of Healing"
+level = 2
+school = "evocation"
+casting_time = "10 minutes"
+range = "30 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = false
+material = false
+concentration = false
+ritual = false
+classes = ["cleric"]
+
+[spell.protection_from_poison]
+name = "Protection from Poison"
+level = 2
+school = "abjuration"
+casting_time = "1 action"
+range = "Touch"
+duration = "1 hour"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["cleric", "druid", "paladin", "ranger"]
+
+[spell.ray_of_enfeeblement]
+name = "Ray of Enfeeblement"
+level = 2
+school = "necromancy"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["warlock", "wizard"]
+
+[spell.rope_trick]
+name = "Rope Trick"
+level = 2
+school = "transmutation"
+casting_time = "1 action"
+range = "Touch"
+duration = "1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["wizard"]
+
+[spell.scorching_ray]
+name = "Scorching Ray"
+level = 2
+school = "evocation"
+casting_time = "1 action"
+range = "120 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.see_invisibility]
+name = "See Invisibility"
+level = 2
+school = "divination"
+casting_time = "1 action"
+range = "Self"
+duration = "1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "sorcerer", "wizard"]
+
+[spell.shatter]
+name = "Shatter"
+level = 2
+school = "evocation"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "sorcerer", "warlock", "wizard"]
+
+[spell.silence]
+name = "Silence"
+level = 2
+school = "illusion"
+casting_time = "1 action"
+range = "120 feet"
+duration = "Concentration, up to 10 minutes"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = true
+classes = ["bard", "cleric", "ranger"]
+
+[spell.spider_climb]
+name = "Spider Climb"
+level = 2
+school = "transmutation"
+casting_time = "1 action"
+range = "Touch"
+duration = "Concentration, up to 1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["sorcerer", "warlock", "wizard"]
+
+[spell.spike_growth]
+name = "Spike Growth"
+level = 2
+school = "transmutation"
+casting_time = "1 action"
+range = "150 feet"
+duration = "Concentration, up to 10 minutes"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["druid", "ranger"]
+
+[spell.spiritual_weapon]
+name = "Spiritual Weapon"
+level = 2
+school = "evocation"
+casting_time = "1 bonus action"
+range = "60 feet"
+duration = "1 minute"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["cleric"]
+
+[spell.suggestion]
+name = "Suggestion"
+level = 2
+school = "enchantment"
+casting_time = "1 action"
+range = "30 feet"
+duration = "Concentration, up to 8 hours"
+verbal = true
+somatic = false
+material = true
+concentration = true
+ritual = false
+classes = ["bard", "sorcerer", "warlock", "wizard"]
+
+[spell.warding_bond]
+name = "Warding Bond"
+level = 2
+school = "abjuration"
+casting_time = "1 action"
+range = "Touch"
+duration = "1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["cleric"]
+
+[spell.web]
+name = "Web"
+level = 2
+school = "conjuration"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Concentration, up to 1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.zone_of_truth]
+name = "Zone of Truth"
+level = 2
+school = "enchantment"
+casting_time = "1 action"
+range = "60 feet"
+duration = "10 minutes"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["bard", "cleric"]
+
+[spell.acid_arrow]
+name = "Acid Arrow"
+level = 2
+school = "evocation"
+casting_time = "1 action"
+range = "90 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["wizard"]
+
+[spell.mirror_image]
+name = "Mirror Image"
+level = 2
+school = "illusion"
+casting_time = "1 action"
+range = "Self"
+duration = "1 minute"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["sorcerer", "warlock", "wizard"]

--- a/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/spell/level_3.toml
+++ b/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/spell/level_3.toml
@@ -1,0 +1,601 @@
+[spell.animate_dead]
+name = "Animate Dead"
+level = 3
+school = "necromancy"
+casting_time = "1 minute"
+range = "10 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["cleric", "wizard"]
+
+[spell.beacon_of_hope]
+name = "Beacon of Hope"
+level = 3
+school = "abjuration"
+casting_time = "1 action"
+range = "30 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["cleric"]
+
+[spell.bestow_curse]
+name = "Bestow Curse"
+level = 3
+school = "necromancy"
+casting_time = "1 action"
+range = "Touch"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["bard", "cleric", "wizard"]
+
+[spell.blink]
+name = "Blink"
+level = 3
+school = "transmutation"
+casting_time = "1 action"
+range = "Self"
+duration = "1 minute"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.call_lightning]
+name = "Call Lightning"
+level = 3
+school = "conjuration"
+casting_time = "1 action"
+range = "120 feet"
+duration = "Concentration, up to 10 minutes"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["druid"]
+
+[spell.clairvoyance]
+name = "Clairvoyance"
+level = 3
+school = "divination"
+casting_time = "10 minutes"
+range = "1 mile"
+duration = "Concentration, up to 10 minutes"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["bard", "cleric", "sorcerer", "wizard"]
+
+[spell.conjure_animals]
+name = "Conjure Animals"
+level = 3
+school = "conjuration"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Concentration, up to 1 hour"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["druid", "ranger"]
+
+[spell.counterspell]
+name = "Counterspell"
+level = 3
+school = "abjuration"
+casting_time = "1 reaction"
+range = "60 feet"
+duration = "Instantaneous"
+verbal = false
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["sorcerer", "warlock", "wizard"]
+
+[spell.create_food_and_water]
+name = "Create Food and Water"
+level = 3
+school = "conjuration"
+casting_time = "1 action"
+range = "30 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["cleric", "paladin"]
+
+[spell.daylight]
+name = "Daylight"
+level = 3
+school = "evocation"
+casting_time = "1 action"
+range = "60 feet"
+duration = "1 hour"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["cleric", "druid", "paladin", "ranger", "sorcerer"]
+
+[spell.dispel_magic]
+name = "Dispel Magic"
+level = 3
+school = "abjuration"
+casting_time = "1 action"
+range = "120 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["bard", "cleric", "druid", "paladin", "sorcerer", "warlock", "wizard"]
+
+[spell.fear]
+name = "Fear"
+level = 3
+school = "illusion"
+casting_time = "1 action"
+range = "Self (30-foot cone)"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["bard", "sorcerer", "warlock", "wizard"]
+
+[spell.feign_death]
+name = "Feign Death"
+level = 3
+school = "necromancy"
+casting_time = "1 action"
+range = "Touch"
+duration = "1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = true
+classes = ["bard", "cleric", "druid", "wizard"]
+
+[spell.fireball]
+name = "Fireball"
+level = 3
+school = "evocation"
+casting_time = "1 action"
+range = "150 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.fly]
+name = "Fly"
+level = 3
+school = "transmutation"
+casting_time = "1 action"
+range = "Touch"
+duration = "Concentration, up to 10 minutes"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["sorcerer", "warlock", "wizard"]
+
+[spell.gaseous_form]
+name = "Gaseous Form"
+level = 3
+school = "transmutation"
+casting_time = "1 action"
+range = "Touch"
+duration = "Concentration, up to 1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["sorcerer", "warlock", "wizard"]
+
+[spell.glyph_of_warding]
+name = "Glyph of Warding"
+level = 3
+school = "abjuration"
+casting_time = "1 hour"
+range = "Touch"
+duration = "Until dispelled or triggered"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "cleric", "wizard"]
+
+[spell.haste]
+name = "Haste"
+level = 3
+school = "transmutation"
+casting_time = "1 action"
+range = "30 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.hypnotic_pattern]
+name = "Hypnotic Pattern"
+level = 3
+school = "illusion"
+casting_time = "1 action"
+range = "120 feet"
+duration = "Concentration, up to 1 minute"
+verbal = false
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["bard", "sorcerer", "warlock", "wizard"]
+
+[spell.tiny_hut]
+name = "Tiny Hut"
+level = 3
+school = "evocation"
+casting_time = "1 minute"
+range = "Self (10-foot-radius hemisphere)"
+duration = "8 hours"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = true
+classes = ["bard", "wizard"]
+
+[spell.lightning_bolt]
+name = "Lightning Bolt"
+level = 3
+school = "evocation"
+casting_time = "1 action"
+range = "Self (100-foot line)"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.magic_circle]
+name = "Magic Circle"
+level = 3
+school = "abjuration"
+casting_time = "1 minute"
+range = "10 feet"
+duration = "1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["cleric", "paladin", "warlock", "wizard"]
+
+[spell.major_image]
+name = "Major Image"
+level = 3
+school = "illusion"
+casting_time = "1 action"
+range = "120 feet"
+duration = "Concentration, up to 10 minutes"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["bard", "sorcerer", "warlock", "wizard"]
+
+[spell.mass_healing_word]
+name = "Mass Healing Word"
+level = 3
+school = "evocation"
+casting_time = "1 bonus action"
+range = "60 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = false
+material = false
+concentration = false
+ritual = false
+classes = ["bard", "cleric"]
+
+[spell.meld_into_stone]
+name = "Meld into Stone"
+level = 3
+school = "transmutation"
+casting_time = "1 action"
+range = "Touch"
+duration = "8 hours"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = true
+classes = ["cleric", "druid"]
+
+[spell.nondetection]
+name = "Nondetection"
+level = 3
+school = "abjuration"
+casting_time = "1 action"
+range = "Touch"
+duration = "8 hours"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "ranger", "wizard"]
+
+[spell.phantom_steed]
+name = "Phantom Steed"
+level = 3
+school = "illusion"
+casting_time = "1 minute"
+range = "30 feet"
+duration = "1 hour"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = true
+classes = ["wizard"]
+
+[spell.plant_growth]
+name = "Plant Growth"
+level = 3
+school = "transmutation"
+casting_time = "1 action"
+range = "150 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["bard", "druid", "ranger"]
+
+[spell.protection_from_energy]
+name = "Protection from Energy"
+level = 3
+school = "abjuration"
+casting_time = "1 action"
+range = "Touch"
+duration = "Concentration, up to 1 hour"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["cleric", "druid", "ranger", "sorcerer", "wizard"]
+
+[spell.remove_curse]
+name = "Remove Curse"
+level = 3
+school = "abjuration"
+casting_time = "1 action"
+range = "Touch"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["cleric", "paladin", "warlock", "wizard"]
+
+[spell.revivify]
+name = "Revivify"
+level = 3
+school = "necromancy"
+casting_time = "1 action"
+range = "Touch"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["cleric", "druid", "paladin"]
+
+[spell.sending]
+name = "Sending"
+level = 3
+school = "evocation"
+casting_time = "1 action"
+range = "Unlimited"
+duration = "1 round"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "cleric", "wizard"]
+
+[spell.sleet_storm]
+name = "Sleet Storm"
+level = 3
+school = "conjuration"
+casting_time = "1 action"
+range = "150 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["druid", "sorcerer", "wizard"]
+
+[spell.slow]
+name = "Slow"
+level = 3
+school = "transmutation"
+casting_time = "1 action"
+range = "120 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.speak_with_dead]
+name = "Speak with Dead"
+level = 3
+school = "necromancy"
+casting_time = "1 action"
+range = "10 feet"
+duration = "10 minutes"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "cleric"]
+
+[spell.speak_with_plants]
+name = "Speak with Plants"
+level = 3
+school = "transmutation"
+casting_time = "1 action"
+range = "Self (30-foot radius)"
+duration = "10 minutes"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["bard", "druid", "ranger"]
+
+[spell.spirit_guardians]
+name = "Spirit Guardians"
+level = 3
+school = "conjuration"
+casting_time = "1 action"
+range = "Self (15-foot radius)"
+duration = "Concentration, up to 10 minutes"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["cleric"]
+
+[spell.stinking_cloud]
+name = "Stinking Cloud"
+level = 3
+school = "conjuration"
+casting_time = "1 action"
+range = "90 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["bard", "sorcerer", "wizard"]
+
+[spell.tongues]
+name = "Tongues"
+level = 3
+school = "divination"
+casting_time = "1 action"
+range = "Touch"
+duration = "1 hour"
+verbal = true
+somatic = false
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "cleric", "sorcerer", "warlock", "wizard"]
+
+[spell.vampiric_touch]
+name = "Vampiric Touch"
+level = 3
+school = "necromancy"
+casting_time = "1 action"
+range = "Self"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["warlock", "wizard"]
+
+[spell.water_breathing]
+name = "Water Breathing"
+level = 3
+school = "transmutation"
+casting_time = "1 action"
+range = "30 feet"
+duration = "24 hours"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = true
+classes = ["druid", "ranger", "sorcerer", "wizard"]
+
+[spell.water_walk]
+name = "Water Walk"
+level = 3
+school = "transmutation"
+casting_time = "1 action"
+range = "30 feet"
+duration = "1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = true
+classes = ["cleric", "druid", "ranger", "sorcerer"]
+
+[spell.wind_wall]
+name = "Wind Wall"
+level = 3
+school = "evocation"
+casting_time = "1 action"
+range = "120 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["druid", "ranger"]

--- a/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/spell/level_4.toml
+++ b/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/spell/level_4.toml
@@ -1,0 +1,433 @@
+[spell.arcane_eye]
+name = "Arcane Eye"
+level = 4
+school = "divination"
+casting_time = "1 action"
+range = "30 feet"
+duration = "Concentration, up to 1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["wizard"]
+
+[spell.banishment]
+name = "Banishment"
+level = 4
+school = "abjuration"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["cleric", "paladin", "sorcerer", "warlock", "wizard"]
+
+[spell.black_tentacles]
+name = "Black Tentacles"
+level = 4
+school = "conjuration"
+casting_time = "1 action"
+range = "90 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["wizard"]
+
+[spell.blight]
+name = "Blight"
+level = 4
+school = "necromancy"
+casting_time = "1 action"
+range = "30 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["druid", "sorcerer", "warlock", "wizard"]
+
+[spell.compulsion]
+name = "Compulsion"
+level = 4
+school = "enchantment"
+casting_time = "1 action"
+range = "30 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["bard"]
+
+[spell.confusion]
+name = "Confusion"
+level = 4
+school = "enchantment"
+casting_time = "1 action"
+range = "90 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["bard", "druid", "sorcerer", "wizard"]
+
+[spell.conjure_minor_elementals]
+name = "Conjure Minor Elementals"
+level = 4
+school = "conjuration"
+casting_time = "1 minute"
+range = "90 feet"
+duration = "Concentration, up to 1 hour"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["druid", "wizard"]
+
+[spell.conjure_woodland_beings]
+name = "Conjure Woodland Beings"
+level = 4
+school = "conjuration"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Concentration, up to 1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["druid", "ranger"]
+
+[spell.control_water]
+name = "Control Water"
+level = 4
+school = "transmutation"
+casting_time = "1 action"
+range = "300 feet"
+duration = "Concentration, up to 10 minutes"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["cleric", "druid", "wizard"]
+
+[spell.death_ward]
+name = "Death Ward"
+level = 4
+school = "abjuration"
+casting_time = "1 action"
+range = "Touch"
+duration = "8 hours"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["cleric", "paladin"]
+
+[spell.dimension_door]
+name = "Dimension Door"
+level = 4
+school = "conjuration"
+casting_time = "1 action"
+range = "500 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = false
+material = false
+concentration = false
+ritual = false
+classes = ["bard", "sorcerer", "warlock", "wizard"]
+
+[spell.divination]
+name = "Divination"
+level = 4
+school = "divination"
+casting_time = "1 action"
+range = "Self"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = true
+classes = ["cleric"]
+
+[spell.dominate_beast]
+name = "Dominate Beast"
+level = 4
+school = "enchantment"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["druid", "sorcerer"]
+
+[spell.fabricate]
+name = "Fabricate"
+level = 4
+school = "transmutation"
+casting_time = "10 minutes"
+range = "120 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["wizard"]
+
+[spell.fire_shield]
+name = "Fire Shield"
+level = 4
+school = "evocation"
+casting_time = "1 action"
+range = "Self"
+duration = "10 minutes"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["wizard"]
+
+[spell.freedom_of_movement]
+name = "Freedom of Movement"
+level = 4
+school = "abjuration"
+casting_time = "1 action"
+range = "Touch"
+duration = "1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "cleric", "druid", "ranger"]
+
+[spell.giant_insect]
+name = "Giant Insect"
+level = 4
+school = "transmutation"
+casting_time = "1 action"
+range = "30 feet"
+duration = "Concentration, up to 10 minutes"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["druid"]
+
+[spell.greater_invisibility]
+name = "Greater Invisibility"
+level = 4
+school = "illusion"
+casting_time = "1 action"
+range = "Touch"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["bard", "sorcerer", "wizard"]
+
+[spell.guardian_of_faith]
+name = "Guardian of Faith"
+level = 4
+school = "conjuration"
+casting_time = "1 action"
+range = "30 feet"
+duration = "8 hours"
+verbal = true
+somatic = false
+material = false
+concentration = false
+ritual = false
+classes = ["cleric"]
+
+[spell.hallucinatory_terrain]
+name = "Hallucinatory Terrain"
+level = 4
+school = "illusion"
+casting_time = "10 minutes"
+range = "300 feet"
+duration = "24 hours"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "druid", "warlock", "wizard"]
+
+[spell.ice_storm]
+name = "Ice Storm"
+level = 4
+school = "evocation"
+casting_time = "1 action"
+range = "300 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["druid", "sorcerer", "wizard"]
+
+[spell.secret_chest]
+name = "Secret Chest"
+level = 4
+school = "conjuration"
+casting_time = "1 action"
+range = "Touch"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["wizard"]
+
+[spell.locate_creature]
+name = "Locate Creature"
+level = 4
+school = "divination"
+casting_time = "1 action"
+range = "Self"
+duration = "Concentration, up to 1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["bard", "cleric", "druid", "paladin", "ranger", "wizard"]
+
+[spell.faithful_hound]
+name = "Faithful Hound"
+level = 4
+school = "conjuration"
+casting_time = "1 action"
+range = "30 feet"
+duration = "8 hours"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["wizard"]
+
+[spell.private_sanctum]
+name = "Private Sanctum"
+level = 4
+school = "abjuration"
+casting_time = "10 minutes"
+range = "120 feet"
+duration = "24 hours"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["wizard"]
+
+[spell.resilient_sphere]
+name = "Resilient Sphere"
+level = 4
+school = "evocation"
+casting_time = "1 action"
+range = "30 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["wizard"]
+
+[spell.phantasmal_killer]
+name = "Phantasmal Killer"
+level = 4
+school = "illusion"
+casting_time = "1 action"
+range = "120 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["wizard"]
+
+[spell.polymorph]
+name = "Polymorph"
+level = 4
+school = "transmutation"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Concentration, up to 1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["bard", "druid", "sorcerer", "wizard"]
+
+[spell.stone_shape]
+name = "Stone Shape"
+level = 4
+school = "transmutation"
+casting_time = "1 action"
+range = "Touch"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["cleric", "druid", "wizard"]
+
+[spell.stoneskin]
+name = "Stoneskin"
+level = 4
+school = "abjuration"
+casting_time = "1 action"
+range = "Touch"
+duration = "Concentration, up to 1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["druid", "ranger", "sorcerer", "wizard"]
+
+[spell.wall_of_fire]
+name = "Wall of Fire"
+level = 4
+school = "evocation"
+casting_time = "1 action"
+range = "120 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["druid", "sorcerer", "wizard"]

--- a/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/spell/level_5.toml
+++ b/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/spell/level_5.toml
@@ -1,0 +1,517 @@
+[spell.animate_objects]
+name = "Animate Objects"
+level = 5
+school = "transmutation"
+casting_time = "1 action"
+range = "120 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["bard", "sorcerer", "wizard"]
+
+[spell.antilife_shell]
+name = "Antilife Shell"
+level = 5
+school = "abjuration"
+casting_time = "1 action"
+range = "Self (10-foot radius)"
+duration = "Concentration, up to 1 hour"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["druid"]
+
+[spell.arcane_hand]
+name = "Arcane Hand"
+level = 5
+school = "evocation"
+casting_time = "1 action"
+range = "120 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["wizard"]
+
+[spell.cloudkill]
+name = "Cloudkill"
+level = 5
+school = "conjuration"
+casting_time = "1 action"
+range = "120 feet"
+duration = "Concentration, up to 10 minutes"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.commune]
+name = "Commune"
+level = 5
+school = "divination"
+casting_time = "1 minute"
+range = "Self"
+duration = "1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = true
+classes = ["cleric"]
+
+[spell.commune_with_nature]
+name = "Commune with Nature"
+level = 5
+school = "divination"
+casting_time = "1 minute"
+range = "Self"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = true
+classes = ["druid", "ranger"]
+
+[spell.cone_of_cold]
+name = "Cone of Cold"
+level = 5
+school = "evocation"
+casting_time = "1 action"
+range = "Self (60-foot cone)"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.conjure_elemental]
+name = "Conjure Elemental"
+level = 5
+school = "conjuration"
+casting_time = "1 minute"
+range = "90 feet"
+duration = "Concentration, up to 1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["druid", "wizard"]
+
+[spell.contact_other_plane]
+name = "Contact Other Plane"
+level = 5
+school = "divination"
+casting_time = "1 minute"
+range = "Self"
+duration = "1 minute"
+verbal = true
+somatic = false
+material = false
+concentration = false
+ritual = true
+classes = ["warlock", "wizard"]
+
+[spell.contagion]
+name = "Contagion"
+level = 5
+school = "necromancy"
+casting_time = "1 action"
+range = "Touch"
+duration = "7 days"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["cleric", "druid"]
+
+[spell.creation]
+name = "Creation"
+level = 5
+school = "illusion"
+casting_time = "1 minute"
+range = "30 feet"
+duration = "Special"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.dispel_evil_and_good]
+name = "Dispel Evil and Good"
+level = 5
+school = "abjuration"
+casting_time = "1 action"
+range = "Self"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["cleric", "paladin"]
+
+[spell.dominate_person]
+name = "Dominate Person"
+level = 5
+school = "enchantment"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["bard", "sorcerer", "wizard"]
+
+[spell.dream]
+name = "Dream"
+level = 5
+school = "illusion"
+casting_time = "1 minute"
+range = "Special"
+duration = "8 hours"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "warlock", "wizard"]
+
+[spell.flame_strike]
+name = "Flame Strike"
+level = 5
+school = "evocation"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["cleric"]
+
+[spell.geas]
+name = "Geas"
+level = 5
+school = "enchantment"
+casting_time = "1 minute"
+range = "60 feet"
+duration = "30 days"
+verbal = true
+somatic = false
+material = false
+concentration = false
+ritual = false
+classes = ["bard", "cleric", "druid", "paladin", "wizard"]
+
+[spell.greater_restoration]
+name = "Greater Restoration"
+level = 5
+school = "abjuration"
+casting_time = "1 action"
+range = "Touch"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "cleric", "druid"]
+
+[spell.hold_monster]
+name = "Hold Monster"
+level = 5
+school = "enchantment"
+casting_time = "1 action"
+range = "90 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["bard", "sorcerer", "warlock", "wizard"]
+
+[spell.insect_plague]
+name = "Insect Plague"
+level = 5
+school = "conjuration"
+casting_time = "1 action"
+range = "300 feet"
+duration = "Concentration, up to 10 minutes"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["cleric", "druid", "sorcerer"]
+
+[spell.legend_lore]
+name = "Legend Lore"
+level = 5
+school = "divination"
+casting_time = "10 minutes"
+range = "Self"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "cleric", "wizard"]
+
+[spell.mass_cure_wounds]
+name = "Mass Cure Wounds"
+level = 5
+school = "evocation"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["bard", "cleric", "druid"]
+
+[spell.mislead]
+name = "Mislead"
+level = 5
+school = "illusion"
+casting_time = "1 action"
+range = "Self"
+duration = "Concentration, up to 1 hour"
+verbal = false
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["bard", "wizard"]
+
+[spell.modify_memory]
+name = "Modify Memory"
+level = 5
+school = "enchantment"
+casting_time = "1 action"
+range = "30 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["bard", "wizard"]
+
+[spell.passwall]
+name = "Passwall"
+level = 5
+school = "transmutation"
+casting_time = "1 action"
+range = "30 feet"
+duration = "1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["wizard"]
+
+[spell.planar_binding]
+name = "Planar Binding"
+level = 5
+school = "abjuration"
+casting_time = "1 hour"
+range = "60 feet"
+duration = "24 hours"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "cleric", "druid", "wizard"]
+
+[spell.raise_dead]
+name = "Raise Dead"
+level = 5
+school = "necromancy"
+casting_time = "1 hour"
+range = "Touch"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "cleric", "paladin"]
+
+[spell.reincarnate]
+name = "Reincarnate"
+level = 5
+school = "transmutation"
+casting_time = "1 hour"
+range = "Touch"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["druid"]
+
+[spell.telepathic_bond]
+name = "Telepathic Bond"
+level = 5
+school = "divination"
+casting_time = "1 action"
+range = "30 feet"
+duration = "1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = true
+classes = ["wizard"]
+
+[spell.scrying]
+name = "Scrying"
+level = 5
+school = "divination"
+casting_time = "10 minutes"
+range = "Self"
+duration = "Concentration, up to 10 minutes"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["bard", "cleric", "druid", "paladin", "warlock", "wizard"]
+
+[spell.seeming]
+name = "Seeming"
+level = 5
+school = "illusion"
+casting_time = "1 action"
+range = "30 feet"
+duration = "8 hours"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["bard", "sorcerer", "wizard"]
+
+[spell.telekinesis]
+name = "Telekinesis"
+level = 5
+school = "transmutation"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Concentration, up to 10 minutes"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.teleportation_circle]
+name = "Teleportation Circle"
+level = 5
+school = "conjuration"
+casting_time = "1 minute"
+range = "10 feet"
+duration = "1 round"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "sorcerer", "wizard"]
+
+[spell.tree_stride]
+name = "Tree Stride"
+level = 5
+school = "conjuration"
+casting_time = "1 action"
+range = "Self"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["druid", "ranger"]
+
+[spell.wall_of_force]
+name = "Wall of Force"
+level = 5
+school = "evocation"
+casting_time = "1 action"
+range = "120 feet"
+duration = "Concentration, up to 10 minutes"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["wizard"]
+
+[spell.wall_of_stone]
+name = "Wall of Stone"
+level = 5
+school = "evocation"
+casting_time = "1 action"
+range = "120 feet"
+duration = "Concentration, up to 10 minutes"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["cleric", "druid", "sorcerer", "wizard"]
+
+[spell.awaken]
+name = "Awaken"
+level = 5
+school = "transmutation"
+casting_time = "8 hours"
+range = "Touch"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "druid"]
+
+[spell.hallow]
+name = "Hallow"
+level = 5
+school = "evocation"
+casting_time = "24 hours"
+range = "Touch"
+duration = "Until dispelled"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["cleric"]

--- a/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/spell/level_6.toml
+++ b/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/spell/level_6.toml
@@ -1,0 +1,447 @@
+[spell.arcane_gate]
+name = "Arcane Gate"
+level = 6
+school = "conjuration"
+casting_time = "1 action"
+range = "500 feet"
+duration = "Concentration, up to 10 minutes"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["sorcerer", "warlock", "wizard"]
+
+[spell.blade_barrier]
+name = "Blade Barrier"
+level = 6
+school = "evocation"
+casting_time = "1 action"
+range = "90 feet"
+duration = "Concentration, up to 10 minutes"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["cleric"]
+
+[spell.chain_lightning]
+name = "Chain Lightning"
+level = 6
+school = "evocation"
+casting_time = "1 action"
+range = "150 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.circle_of_death]
+name = "Circle of Death"
+level = 6
+school = "necromancy"
+casting_time = "1 action"
+range = "150 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["sorcerer", "warlock", "wizard"]
+
+[spell.conjure_fey]
+name = "Conjure Fey"
+level = 6
+school = "conjuration"
+casting_time = "1 minute"
+range = "90 feet"
+duration = "Concentration, up to 1 hour"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["druid", "warlock"]
+
+[spell.contingency]
+name = "Contingency"
+level = 6
+school = "evocation"
+casting_time = "10 minutes"
+range = "Self"
+duration = "10 days"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["wizard"]
+
+[spell.create_undead]
+name = "Create Undead"
+level = 6
+school = "necromancy"
+casting_time = "1 minute"
+range = "10 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["cleric", "warlock", "wizard"]
+
+[spell.disintegrate]
+name = "Disintegrate"
+level = 6
+school = "transmutation"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.instant_summons]
+name = "Instant Summons"
+level = 6
+school = "conjuration"
+casting_time = "1 minute"
+range = "Touch"
+duration = "Until dispelled"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = true
+classes = ["wizard"]
+
+[spell.eyebite]
+name = "Eyebite"
+level = 6
+school = "necromancy"
+casting_time = "1 action"
+range = "Self"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["bard", "sorcerer", "warlock", "wizard"]
+
+[spell.find_the_path]
+name = "Find the Path"
+level = 6
+school = "divination"
+casting_time = "1 minute"
+range = "Self"
+duration = "Concentration, up to 1 day"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["bard", "cleric", "druid"]
+
+[spell.flesh_to_stone]
+name = "Flesh to Stone"
+level = 6
+school = "transmutation"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["wizard"]
+
+[spell.forbiddance]
+name = "Forbiddance"
+level = 6
+school = "abjuration"
+casting_time = "10 minutes"
+range = "Touch"
+duration = "1 day"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = true
+classes = ["cleric"]
+
+[spell.freezing_sphere]
+name = "Freezing Sphere"
+level = 6
+school = "evocation"
+casting_time = "1 action"
+range = "300 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["wizard"]
+
+[spell.globe_of_invulnerability]
+name = "Globe of Invulnerability"
+level = 6
+school = "abjuration"
+casting_time = "1 action"
+range = "Self (10-foot radius)"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.guards_and_wards]
+name = "Guards and Wards"
+level = 6
+school = "abjuration"
+casting_time = "10 minutes"
+range = "Touch"
+duration = "24 hours"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "wizard"]
+
+[spell.harm]
+name = "Harm"
+level = 6
+school = "necromancy"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["cleric"]
+
+[spell.heal]
+name = "Heal"
+level = 6
+school = "evocation"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["cleric", "druid"]
+
+[spell.heroes_feast]
+name = "Heroes' Feast"
+level = 6
+school = "conjuration"
+casting_time = "10 minutes"
+range = "30 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["cleric", "druid"]
+
+[spell.magic_jar]
+name = "Magic Jar"
+level = 6
+school = "necromancy"
+casting_time = "1 minute"
+range = "Self"
+duration = "Until dispelled"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["wizard"]
+
+[spell.mass_suggestion]
+name = "Mass Suggestion"
+level = 6
+school = "enchantment"
+casting_time = "1 action"
+range = "60 feet"
+duration = "24 hours"
+verbal = true
+somatic = false
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "sorcerer", "warlock", "wizard"]
+
+[spell.move_earth]
+name = "Move Earth"
+level = 6
+school = "transmutation"
+casting_time = "1 action"
+range = "120 feet"
+duration = "Concentration, up to 2 hours"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["druid", "sorcerer", "wizard"]
+
+[spell.irresistible_dance]
+name = "Irresistible Dance"
+level = 6
+school = "enchantment"
+casting_time = "1 action"
+range = "30 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = false
+material = false
+concentration = true
+ritual = false
+classes = ["bard", "wizard"]
+
+[spell.planar_ally]
+name = "Planar Ally"
+level = 6
+school = "conjuration"
+casting_time = "10 minutes"
+range = "60 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["cleric"]
+
+[spell.programmed_illusion]
+name = "Programmed Illusion"
+level = 6
+school = "illusion"
+casting_time = "1 action"
+range = "120 feet"
+duration = "Until dispelled"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "wizard"]
+
+[spell.sunbeam]
+name = "Sunbeam"
+level = 6
+school = "evocation"
+casting_time = "1 action"
+range = "Self (60-foot line)"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["druid", "sorcerer", "wizard"]
+
+[spell.transport_via_plants]
+name = "Transport via Plants"
+level = 6
+school = "conjuration"
+casting_time = "1 action"
+range = "10 feet"
+duration = "1 round"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["druid"]
+
+[spell.true_seeing]
+name = "True Seeing"
+level = 6
+school = "divination"
+casting_time = "1 action"
+range = "Touch"
+duration = "1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "cleric", "sorcerer", "warlock", "wizard"]
+
+[spell.wall_of_ice]
+name = "Wall of Ice"
+level = 6
+school = "evocation"
+casting_time = "1 action"
+range = "120 feet"
+duration = "Concentration, up to 10 minutes"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["wizard"]
+
+[spell.wall_of_thorns]
+name = "Wall of Thorns"
+level = 6
+school = "conjuration"
+casting_time = "1 action"
+range = "120 feet"
+duration = "Concentration, up to 10 minutes"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["druid"]
+
+[spell.wind_walk]
+name = "Wind Walk"
+level = 6
+school = "transmutation"
+casting_time = "1 minute"
+range = "30 feet"
+duration = "8 hours"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["druid"]
+
+[spell.word_of_recall]
+name = "Word of Recall"
+level = 6
+school = "conjuration"
+casting_time = "1 action"
+range = "5 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = false
+material = false
+concentration = false
+ritual = false
+classes = ["cleric"]

--- a/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/spell/level_7.toml
+++ b/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/spell/level_7.toml
@@ -1,0 +1,279 @@
+[spell.conjure_celestial]
+name = "Conjure Celestial"
+level = 7
+school = "conjuration"
+casting_time = "1 minute"
+range = "90 feet"
+duration = "Concentration, up to 1 hour"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["cleric"]
+
+[spell.delayed_blast_fireball]
+name = "Delayed Blast Fireball"
+level = 7
+school = "evocation"
+casting_time = "1 action"
+range = "150 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.divine_word]
+name = "Divine Word"
+level = 7
+school = "evocation"
+casting_time = "1 bonus action"
+range = "30 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = false
+material = false
+concentration = false
+ritual = false
+classes = ["cleric"]
+
+[spell.etherealness]
+name = "Etherealness"
+level = 7
+school = "transmutation"
+casting_time = "1 action"
+range = "Self"
+duration = "Up to 8 hours"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["bard", "cleric", "sorcerer", "warlock", "wizard"]
+
+[spell.finger_of_death]
+name = "Finger of Death"
+level = 7
+school = "necromancy"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["sorcerer", "warlock", "wizard"]
+
+[spell.fire_storm]
+name = "Fire Storm"
+level = 7
+school = "evocation"
+casting_time = "1 action"
+range = "150 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["cleric", "druid", "sorcerer"]
+
+[spell.forcecage]
+name = "Forcecage"
+level = 7
+school = "evocation"
+casting_time = "1 action"
+range = "100 feet"
+duration = "1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "warlock", "wizard"]
+
+[spell.mirage_arcane]
+name = "Mirage Arcane"
+level = 7
+school = "illusion"
+casting_time = "10 minutes"
+range = "Sight"
+duration = "10 days"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["bard", "druid", "wizard"]
+
+[spell.magnificent_mansion]
+name = "Magnificent Mansion"
+level = 7
+school = "conjuration"
+casting_time = "1 minute"
+range = "300 feet"
+duration = "24 hours"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "wizard"]
+
+[spell.arcane_sword]
+name = "Arcane Sword"
+level = 7
+school = "evocation"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["bard", "wizard"]
+
+[spell.plane_shift]
+name = "Plane Shift"
+level = 7
+school = "conjuration"
+casting_time = "1 action"
+range = "Touch"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["cleric", "druid", "sorcerer", "warlock", "wizard"]
+
+[spell.prismatic_spray]
+name = "Prismatic Spray"
+level = 7
+school = "evocation"
+casting_time = "1 action"
+range = "Self (60-foot cone)"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.project_image]
+name = "Project Image"
+level = 7
+school = "illusion"
+casting_time = "1 action"
+range = "500 miles"
+duration = "Concentration, up to 1 day"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["bard", "wizard"]
+
+[spell.regenerate]
+name = "Regenerate"
+level = 7
+school = "transmutation"
+casting_time = "1 minute"
+range = "Touch"
+duration = "1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "cleric", "druid"]
+
+[spell.resurrection]
+name = "Resurrection"
+level = 7
+school = "necromancy"
+casting_time = "1 hour"
+range = "Touch"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "cleric"]
+
+[spell.reverse_gravity]
+name = "Reverse Gravity"
+level = 7
+school = "transmutation"
+casting_time = "1 action"
+range = "100 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["druid", "sorcerer", "wizard"]
+
+[spell.sequester]
+name = "Sequester"
+level = 7
+school = "transmutation"
+casting_time = "1 action"
+range = "Touch"
+duration = "Until dispelled"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["wizard"]
+
+[spell.simulacrum]
+name = "Simulacrum"
+level = 7
+school = "illusion"
+casting_time = "12 hours"
+range = "Touch"
+duration = "Until dispelled"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["wizard"]
+
+[spell.symbol]
+name = "Symbol"
+level = 7
+school = "abjuration"
+casting_time = "1 minute"
+range = "Touch"
+duration = "Until dispelled or triggered"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "cleric", "wizard"]
+
+[spell.teleport]
+name = "Teleport"
+level = 7
+school = "conjuration"
+casting_time = "1 action"
+range = "10 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = false
+material = false
+concentration = false
+ritual = false
+classes = ["bard", "sorcerer", "wizard"]

--- a/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/spell/level_8.toml
+++ b/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/spell/level_8.toml
@@ -1,0 +1,237 @@
+[spell.animal_shapes]
+name = "Animal Shapes"
+level = 8
+school = "transmutation"
+casting_time = "1 action"
+range = "30 feet"
+duration = "Concentration, up to 24 hours"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["druid"]
+
+[spell.antimagic_field]
+name = "Antimagic Field"
+level = 8
+school = "abjuration"
+casting_time = "1 action"
+range = "Self (10-foot-radius sphere)"
+duration = "Concentration, up to 1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["cleric", "wizard"]
+
+[spell.antipathy_sympathy]
+name = "Antipathy/Sympathy"
+level = 8
+school = "enchantment"
+casting_time = "1 hour"
+range = "60 feet"
+duration = "10 days"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["druid", "wizard"]
+
+[spell.clone]
+name = "Clone"
+level = 8
+school = "necromancy"
+casting_time = "1 hour"
+range = "Touch"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["wizard"]
+
+[spell.control_weather]
+name = "Control Weather"
+level = 8
+school = "transmutation"
+casting_time = "10 minutes"
+range = "Self (5-mile radius)"
+duration = "Concentration, up to 8 hours"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["cleric", "druid", "wizard"]
+
+[spell.demiplane]
+name = "Demiplane"
+level = 8
+school = "conjuration"
+casting_time = "1 action"
+range = "60 feet"
+duration = "1 hour"
+verbal = false
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["warlock", "wizard"]
+
+[spell.dominate_monster]
+name = "Dominate Monster"
+level = 8
+school = "enchantment"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Concentration, up to 1 hour"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["bard", "sorcerer", "warlock", "wizard"]
+
+[spell.earthquake]
+name = "Earthquake"
+level = 8
+school = "evocation"
+casting_time = "1 action"
+range = "500 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["cleric", "druid", "sorcerer"]
+
+[spell.feeblemind]
+name = "Feeblemind"
+level = 8
+school = "enchantment"
+casting_time = "1 action"
+range = "150 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "druid", "warlock", "wizard"]
+
+[spell.glibness]
+name = "Glibness"
+level = 8
+school = "transmutation"
+casting_time = "1 action"
+range = "Self"
+duration = "1 hour"
+verbal = true
+somatic = false
+material = false
+concentration = false
+ritual = false
+classes = ["bard", "warlock"]
+
+[spell.holy_aura]
+name = "Holy Aura"
+level = 8
+school = "abjuration"
+casting_time = "1 action"
+range = "Self (30-foot radius)"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["cleric"]
+
+[spell.incendiary_cloud]
+name = "Incendiary Cloud"
+level = 8
+school = "conjuration"
+casting_time = "1 action"
+range = "150 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.maze]
+name = "Maze"
+level = 8
+school = "conjuration"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Concentration, up to 10 minutes"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["wizard"]
+
+[spell.mind_blank]
+name = "Mind Blank"
+level = 8
+school = "abjuration"
+casting_time = "1 action"
+range = "Touch"
+duration = "24 hours"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["bard", "wizard"]
+
+[spell.power_word_stun]
+name = "Power Word Stun"
+level = 8
+school = "enchantment"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = false
+material = false
+concentration = false
+ritual = false
+classes = ["bard", "sorcerer", "warlock", "wizard"]
+
+[spell.sunburst]
+name = "Sunburst"
+level = 8
+school = "evocation"
+casting_time = "1 action"
+range = "150 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["druid", "sorcerer", "wizard"]
+
+[spell.tsunami]
+name = "Tsunami"
+level = 8
+school = "conjuration"
+casting_time = "1 minute"
+range = "Sight"
+duration = "Concentration, up to 6 rounds"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["druid"]

--- a/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/spell/level_9.toml
+++ b/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/concepts/spell/level_9.toml
@@ -1,0 +1,223 @@
+[spell.astral_projection]
+name = "Astral Projection"
+level = 9
+school = "necromancy"
+casting_time = "1 hour"
+range = "10 feet"
+duration = "Special"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["cleric", "warlock", "wizard"]
+
+[spell.foresight]
+name = "Foresight"
+level = 9
+school = "divination"
+casting_time = "1 minute"
+range = "Touch"
+duration = "8 hours"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["bard", "druid", "warlock", "wizard"]
+
+[spell.gate]
+name = "Gate"
+level = 9
+school = "conjuration"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["cleric", "sorcerer", "wizard"]
+
+[spell.imprisonment]
+name = "Imprisonment"
+level = 9
+school = "abjuration"
+casting_time = "1 minute"
+range = "30 feet"
+duration = "Until dispelled"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["warlock", "wizard"]
+
+[spell.mass_heal]
+name = "Mass Heal"
+level = 9
+school = "evocation"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["cleric"]
+
+[spell.meteor_swarm]
+name = "Meteor Swarm"
+level = 9
+school = "evocation"
+casting_time = "1 action"
+range = "1 mile"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.power_word_heal]
+name = "Power Word Heal"
+level = 9
+school = "evocation"
+casting_time = "1 action"
+range = "Touch"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["bard", "cleric"]
+
+[spell.power_word_kill]
+name = "Power Word Kill"
+level = 9
+school = "enchantment"
+casting_time = "1 action"
+range = "60 feet"
+duration = "Instantaneous"
+verbal = true
+somatic = false
+material = false
+concentration = false
+ritual = false
+classes = ["bard", "sorcerer", "warlock", "wizard"]
+
+[spell.prismatic_wall]
+name = "Prismatic Wall"
+level = 9
+school = "abjuration"
+casting_time = "1 action"
+range = "60 feet"
+duration = "10 minutes"
+verbal = true
+somatic = true
+material = false
+concentration = false
+ritual = false
+classes = ["wizard"]
+
+[spell.shapechange]
+name = "Shapechange"
+level = 9
+school = "transmutation"
+casting_time = "1 action"
+range = "Self"
+duration = "Concentration, up to 1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["druid", "wizard"]
+
+[spell.storm_of_vengeance]
+name = "Storm of Vengeance"
+level = 9
+school = "conjuration"
+casting_time = "1 action"
+range = "Sight"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["druid"]
+
+[spell.time_stop]
+name = "Time Stop"
+level = 9
+school = "transmutation"
+casting_time = "1 action"
+range = "Self"
+duration = "Instantaneous"
+verbal = true
+somatic = false
+material = false
+concentration = false
+ritual = false
+classes = ["sorcerer", "wizard"]
+
+[spell.true_polymorph]
+name = "True Polymorph"
+level = 9
+school = "transmutation"
+casting_time = "1 action"
+range = "30 feet"
+duration = "Concentration, up to 1 hour"
+verbal = true
+somatic = true
+material = true
+concentration = true
+ritual = false
+classes = ["bard", "sorcerer", "warlock", "wizard"]
+
+[spell.true_resurrection]
+name = "True Resurrection"
+level = 9
+school = "necromancy"
+casting_time = "1 hour"
+range = "Touch"
+duration = "Instantaneous"
+verbal = true
+somatic = true
+material = true
+concentration = false
+ritual = false
+classes = ["cleric", "druid"]
+
+[spell.weird]
+name = "Weird"
+level = 9
+school = "illusion"
+casting_time = "1 action"
+range = "120 feet"
+duration = "Concentration, up to 1 minute"
+verbal = true
+somatic = true
+material = false
+concentration = true
+ritual = false
+classes = ["wizard"]
+
+[spell.wish]
+name = "Wish"
+level = 9
+school = "conjuration"
+casting_time = "1 action"
+range = "Self"
+duration = "Instantaneous"
+verbal = true
+somatic = false
+material = false
+concentration = false
+ritual = false
+classes = ["sorcerer", "wizard"]

--- a/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/module.toml
+++ b/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/module.toml
@@ -66,6 +66,10 @@ name = "Award"
 id = "damage_type"
 name = "Damage Type"
 
+[[concept_type]]
+id = "spell"
+name = "Spell"
+
 [[character_list]]
 label = "Skill Proficiencies"
 metadata_key = "skill_proficiencies"


### PR DESCRIPTION
## Summary

- Adds all 326 SRD 5.1 spells as a new `spell` concept type, organized into TOML files by level (cantrips through level 9)
- Each spell records name, level, school, casting time, range, duration, component flags (V/S/M), concentration, ritual, and class list
- All spell names use the SRD 5.1 versions (personal names stripped, e.g. "Arcane Hand" not "Bigby's Hand")

## Notes

Spell fields are pure metadata (no computed nodes), loading the same way as other reference concepts like languages. Queryable via `{"spell", slug}` in `concept_metadata`.

Slot mechanics (per-class progression tables and slot accumulators) are intentionally deferred to a follow-up PR.

## Test plan

- [x] `mix test --umbrella` passes