### PR TITLE
chore: sync Cargo.toml version with CLI release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,10 @@ jobs:
           ROOT_CURRENT=$(grep -m1 'version:' mix.exs | sed 's/.*version: "//;s/".*//')
           sed -i "0,/version: \"${ROOT_CURRENT}\"/s/version: \"${ROOT_CURRENT}\"/version: \"${CLI_NEW}\"/" mix.exs
 
+          # ---- Rust CLI (tracks CLI version) ----
+          CARGO_CURRENT=$(grep -m1 '^version' cli/Cargo.toml | sed 's/version = "//;s/".*//')
+          sed -i "0,/^version = \"${CARGO_CURRENT}\"/s/^version = \"${CARGO_CURRENT}\"/version = \"${CLI_NEW}\"/" cli/Cargo.toml
+
           # ---- Library ----
           LIB_CURRENT=$(grep -m1 'version:' apps/ex_ttrpg_dev/mix.exs | sed 's/.*version: "//;s/".*//')
           LIB_NEW="$LIB_CURRENT"
@@ -84,7 +88,7 @@ jobs:
       - name: Commit and push version bumps
         id: commit
         run: |
-          git add mix.exs apps/ttrpg_dev_cli/mix.exs
+          git add mix.exs apps/ttrpg_dev_cli/mix.exs cli/Cargo.toml
 
           if [ "${{ steps.bump.outputs.lib_changed }}" == "true" ]; then
             git add apps/ex_ttrpg_dev/mix.exs

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "ttrpg-dev"
-version = "0.1.0"
+version = "0.13.0"
 dependencies = [
  "crossterm",
  "reedline",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ttrpg-dev"
-version = "0.1.0"
+version = "0.13.0"
 edition = "2024"
 license = "AGPL-3.0-or-later"
 


### PR DESCRIPTION
## Summary

- Updates `cli/Cargo.toml` from `0.1.0` to the current CLI version (`0.13.0`)
- Patches `release.yml` to bump `cli/Cargo.toml` alongside `apps/ttrpg_dev_cli/mix.exs` on every release, so the Rust binary always reports the correct version