### PR TITLE
Add `delete` and `delete-all` to charcter hinting

### DIFF
--- a/cli/src/repl.rs
+++ b/cli/src/repl.rs
@@ -57,6 +57,8 @@ static COMMANDS: &[&str] = &[
     "characters roll",
     "characters award",
     "characters choices",
+    "characters delete",
+    "characters delete-all",
     "characters resolve_choice",
     "characters inventory",
     "characters inventory add",


### PR DESCRIPTION
When typing `characters d` and hitting "tab" neither `delete` nor `delete-all` were suggested as options. This fixes that.