### PR TITLE
feat: warn on unknown concept metadata keys at load time

### DIFF
--- a/apps/ex_ttrpg_dev/lib/rule_system/loader.ex
+++ b/apps/ex_ttrpg_dev/lib/rule_system/loader.ex
@@ -107,9 +107,20 @@ defmodule ExTTRPGDev.RuleSystem.Loader do
     display. Has no effect on DAG evaluation.
   """
 
+  require Logger
+
   alias ExTTRPGDev.RuleSystem.{InventoryRules, RuleModule}
 
   @module_file "module.toml"
+
+  # All concept metadata keys read by the library at runtime. Keys not in this
+  # set and not otherwise declared will trigger a Logger.warning at load time.
+  # See the "Structural Vocabulary" section of this module's docs for semantics.
+  @structural_metadata_keys MapSet.new(~w(
+    name type required_count available_when effect_target roll_reference roll
+    filter choices level requires starting_equipment target_type dice bonus_field
+    contributes hidden
+  ))
   @character_building_file "character_building.toml"
   @inventory_rules_file "inventory_rules.toml"
 
@@ -119,6 +130,7 @@ defmodule ExTTRPGDev.RuleSystem.Loader do
          {:ok, data} <- load_concept_files(path, rule_module) do
       inventory_rules = load_inventory_rules(path)
       data = expand_metadata_contributions(data, rule_module)
+      warn_unknown_metadata_keys(data.concept_metadata, rule_module, inventory_rules)
       {:ok, data |> Map.put(:module, rule_module) |> Map.put(:inventory_rules, inventory_rules)}
     end
   end
@@ -321,6 +333,66 @@ defmodule ExTTRPGDev.RuleSystem.Loader do
         end)
         |> Enum.map(fn {{_type, id}, _meta} -> id end)
     end
+  end
+
+  defp warn_unknown_metadata_keys(concept_metadata, rule_module, inventory_rules) do
+    allowed = build_allowed_keys(rule_module, inventory_rules)
+
+    concept_metadata
+    |> Enum.flat_map(fn {{type_id, concept_id}, meta} ->
+      meta
+      |> Map.keys()
+      |> Enum.reject(&MapSet.member?(allowed, &1))
+      |> Enum.map(&{&1, type_id, concept_id})
+    end)
+    |> Enum.group_by(fn {key, type_id, _concept_id} -> {key, type_id} end)
+    |> Enum.sort_by(fn {{key, type_id}, _} -> {type_id, key} end)
+    |> Enum.each(fn {{key, type_id}, instances} ->
+      ids = instances |> Enum.map(fn {_, _, id} -> id end) |> Enum.sort()
+      {shown, rest} = Enum.split(ids, 5)
+      id_str = Enum.join(shown, ", ") <> if(rest == [], do: "", else: " and #{length(rest)} more")
+      count = length(ids)
+      noun = if count == 1, do: "concept", else: "concepts"
+
+      Logger.warning(
+        "Unknown metadata key #{inspect(key)} on #{count} #{inspect(type_id)} #{noun} " <>
+          "in system #{inspect(rule_module.slug)}: #{id_str}. " <>
+          "If intentional, add #{inspect(key)} to custom_metadata_keys in module.toml. " <>
+          "See ExTTRPGDev.RuleSystem.Loader for the structural vocabulary."
+      )
+    end)
+  end
+
+  defp build_allowed_keys(rule_module, inventory_rules) do
+    from_contributions =
+      Enum.flat_map(rule_module.metadata_contributions, fn mc ->
+        [mc.from_field | Enum.map(mc.label_filters, & &1.filter_field)]
+      end)
+
+    [
+      from_contributions,
+      rule_module.custom_metadata_keys,
+      extract_inventory_rules_keys(inventory_rules)
+    ]
+    |> Enum.concat()
+    |> MapSet.new()
+    |> MapSet.union(@structural_metadata_keys)
+  end
+
+  defp extract_inventory_rules_keys(%InventoryRules{types: nil}), do: []
+
+  defp extract_inventory_rules_keys(%InventoryRules{types: types}) do
+    Enum.flat_map(types, fn {_type_id, config} ->
+      case config.preparation do
+        nil ->
+          []
+
+        prep ->
+          base = [prep.mode_field, prep.pool_field, prep.always_prepared_metadata_key]
+          pool_keys = (prep.pools || %{}) |> Map.values() |> Enum.map(& &1.class_filter_field)
+          Enum.filter(base ++ pool_keys, & &1)
+      end
+    end)
   end
 
   defp parse_effect(source, %{"target" => target, "value" => value} = entry) do

--- a/apps/ex_ttrpg_dev/lib/rule_system/rule_module.ex
+++ b/apps/ex_ttrpg_dev/lib/rule_system/rule_module.ex
@@ -69,7 +69,8 @@ defmodule ExTTRPGDev.RuleSystem.RuleModule do
     character_building_choices: [],
     character_lists: [],
     display_config: nil,
-    metadata_contributions: []
+    metadata_contributions: [],
+    custom_metadata_keys: []
   ]
 
   @required_keys ["name", "slug", "version"]
@@ -131,7 +132,8 @@ defmodule ExTTRPGDev.RuleSystem.RuleModule do
          concept_types: concept_types,
          character_lists: character_lists,
          display_config: display_config,
-         metadata_contributions: metadata_contributions
+         metadata_contributions: metadata_contributions,
+         custom_metadata_keys: Map.get(module_map, "custom_metadata_keys", [])
        }}
     end
   end

--- a/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/module.toml
+++ b/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/module.toml
@@ -6,6 +6,31 @@ family = "dungeons_and_dragons"
 series = "dungeons_and_dragons_5e"
 publisher = "Wizards of the Coast, Inc."
 level_node = "character_trait('character_level').level"
+custom_metadata_keys = [
+  # ability / skill display
+  "abbreviation", "description",
+  # award
+  "value_type",
+  # background / race
+  "skill_proficiencies", "damage_resistances", "languages",
+  # character_trait
+  "unit",
+  # class / race
+  "armor_proficiencies", "hit_die", "tool_proficiencies",
+  # currency
+  "in_copper",
+  # equipment — physical properties
+  "category", "cost", "weight", "description",
+  "armor_type", "ac_base", "ac_bonus", "ac_dex_bonus", "ac_dex_max",
+  "stealth_disadvantage", "strength_requirement",
+  "weapon_type", "damages", "properties", "versatile_damage",
+  "range_normal", "range_long", "tool_type",
+  # language
+  "script",
+  # spell display / rules
+  "school", "casting_time", "duration", "range",
+  "concentration", "ritual", "verbal", "somatic", "material"
+]
 
 [[concept_type]]
 id = "ability"

--- a/apps/ex_ttrpg_dev/test/rule_system/loader_test.exs
+++ b/apps/ex_ttrpg_dev/test/rule_system/loader_test.exs
@@ -1,5 +1,6 @@
 defmodule ExTTRPGDev.RuleSystem.LoaderTest do
   use ExUnit.Case, async: true
+  import ExUnit.CaptureLog
   alias ExTTRPGDev.RuleSystem.{InventoryRules, Loader, RuleModule}
 
   defp dnd_path do
@@ -607,5 +608,143 @@ defmodule ExTTRPGDev.RuleSystem.LoaderTest do
     value = 1
     label_filters = []
     """)
+  end
+
+  # --- Metadata key validation ---
+
+  test "dnd_5e_srd loads with no unknown metadata key warnings" do
+    log = capture_log(fn -> Loader.load!(dnd_path()) end)
+
+    assert log == "",
+           "Unexpected metadata key warnings when loading dnd_5e_srd:\n#{log}"
+  end
+
+  test "unknown top-level metadata key produces a warning" do
+    log =
+      with_tmp_system(fn dir ->
+        File.mkdir_p!(Path.join(dir, "concepts/ability"))
+
+        File.write!(Path.join(dir, "concepts/ability/strength.toml"), """
+        [ability.strength]
+        name = "Strength"
+        bogus_field = "this should warn"
+        """)
+
+        capture_log(fn -> Loader.load!(dir) end)
+      end)
+
+    assert log =~ ~s(Unknown metadata key "bogus_field" on 1 "ability" concept)
+    assert log =~ "strength"
+    assert log =~ "custom_metadata_keys"
+  end
+
+  test "structural vocabulary keys do not produce warnings" do
+    log =
+      with_tmp_system(fn dir ->
+        File.mkdir_p!(Path.join(dir, "concepts/ability"))
+
+        File.write!(Path.join(dir, "concepts/ability/strength.toml"), """
+        [ability.strength]
+        name = "Strength"
+        level = 1
+        requires = []
+        """)
+
+        capture_log(fn -> Loader.load!(dir) end)
+      end)
+
+    refute log =~ "Unknown metadata key"
+  end
+
+  test "metadata_contributions from_field keys do not produce warnings" do
+    log =
+      with_tmp_system(["class", "equipment"], fn dir ->
+        File.write!(Path.join(dir, "module.toml"), """
+        [module]
+        name = "Test System"
+        slug = "test_system"
+        version = "0.0.1"
+
+        [[concept_type]]
+        id = "class"
+        name = "Class"
+
+        [[concept_type]]
+        id = "equipment"
+        name = "Equipment"
+
+        [[metadata_contributions]]
+        from_type = "class"
+        from_field = "weapon_proficiencies"
+        to_type = "equipment"
+        to_field = "is_proficient"
+        value = 1
+        label_filters = []
+        """)
+
+        File.mkdir_p!(Path.join(dir, "concepts/class"))
+
+        File.write!(Path.join(dir, "concepts/class/fighter.toml"), """
+        [class.fighter]
+        name = "Fighter"
+        weapon_proficiencies = ["Longsword"]
+        """)
+
+        capture_log(fn -> Loader.load!(dir) end)
+      end)
+
+    refute log =~ ~s("weapon_proficiencies")
+  end
+
+  test "custom_metadata_keys declared in module.toml suppress warnings" do
+    log =
+      with_tmp_system(fn dir ->
+        File.write!(Path.join(dir, "module.toml"), """
+        [module]
+        name = "Test System"
+        slug = "test_system"
+        version = "0.0.1"
+        custom_metadata_keys = ["my_custom_field"]
+
+        [[concept_type]]
+        id = "ability"
+        name = "Ability"
+        """)
+
+        File.mkdir_p!(Path.join(dir, "concepts/ability"))
+
+        File.write!(Path.join(dir, "concepts/ability/strength.toml"), """
+        [ability.strength]
+        name = "Strength"
+        my_custom_field = "intentional domain key"
+        """)
+
+        capture_log(fn -> Loader.load!(dir) end)
+      end)
+
+    refute log =~ "Unknown metadata key"
+  end
+
+  test "warnings group by key and type — one warning per (key, type_id) pair" do
+    log =
+      with_tmp_system(fn dir ->
+        File.mkdir_p!(Path.join(dir, "concepts/ability"))
+
+        File.write!(Path.join(dir, "concepts/ability/attrs.toml"), """
+        [ability.strength]
+        name = "Strength"
+        bogus = true
+
+        [ability.dexterity]
+        name = "Dexterity"
+        bogus = true
+        """)
+
+        capture_log(fn -> Loader.load!(dir) end)
+      end)
+
+    occurrences = log |> String.split("\n") |> Enum.count(&String.contains?(&1, ~s("bogus")))
+    assert occurrences == 1, "Expected one grouped warning for 'bogus', got #{occurrences}"
+    assert log =~ "2 \"ability\" concepts"
   end
 end


### PR DESCRIPTION
## Summary

- Adds `custom_metadata_keys` to `RuleModule` / `module.toml` — the escape hatch for system authors to declare intentional domain keys (display metadata like `school`, `casting_time`, etc.) without triggering warnings
- `Loader.load/1` now calls `warn_unknown_metadata_keys/3` after building the `concept_metadata` map; any key not in the allowed set emits a grouped `Logger.warning` (one per `{key, type_id}`, listing affected concept IDs)
- Allowed keys are the union of: structural vocabulary (18 fixed keys the library reads), `metadata_contributions` `from_field` / `label_filters.filter_field`, `inventory_rules` dynamic field names, and `custom_metadata_keys`
- `dnd_5e_srd/module.toml` gets a `custom_metadata_keys` list (38 domain keys) built empirically via the integration test; loading the system now produces zero warnings

Closes the "Add load-time validation for metadata keys" todo from the over-configurability cleanup list. Warnings now rather than errors — a future breaking release can elevate them once authors have migrated.

## Test plan

- [x] All 49 existing tests pass
- [x] New integration test: `dnd_5e_srd loads with no unknown metadata key warnings` asserts zero log output when loading the full D&D 5e SRD
- [x] Unit tests for: unknown key warns; structural vocab keys don't warn; `metadata_contributions.from_field` keys don't warn; `custom_metadata_keys` suppresses warnings; multi-concept warnings group into one per `{key, type_id}`

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added a new module attribute @structural_metadata_keys containing a MapSet of allowed metadata keys for rule system concepts.</li>
<li>Introduced warn_unknown_metadata_keys function to log warnings for unknown metadata keys found in concept metadata during loading.</li>
<li>Added build_allowed_keys and extract_inventory_rules_keys helper functions to construct the set of allowed metadata keys from rule module and inventory rules.</li>
<li>Modified the load function to call warn_unknown_metadata_keys after expanding metadata contributions.</li>
</ul></div>