### PR TITLE
feat: harden config error messages in loading paths

### DIFF
--- a/apps/ex_ttrpg_dev/lib/rule_system/loader.ex
+++ b/apps/ex_ttrpg_dev/lib/rule_system/loader.ex
@@ -216,7 +216,13 @@ defmodule ExTTRPGDev.RuleSystem.Loader do
   defp process_type("rolling_method", concepts, acc) do
     rolling_methods =
       Enum.reduce(concepts, acc.rolling_methods, fn {id, fields}, rm ->
-        Map.put(rm, id, parse_rolling_method(fields))
+        method = parse_rolling_method(fields)
+
+        if is_nil(method.dice) do
+          Logger.warning("Rolling method #{inspect(id)} is missing required field \"dice\".")
+        end
+
+        Map.put(rm, id, method)
       end)
 
     %{acc | rolling_methods: rolling_methods}
@@ -250,7 +256,9 @@ defmodule ExTTRPGDev.RuleSystem.Loader do
 
         is_map(value) and (Map.has_key?(value, "type") or Map.has_key?(value, "formula")) ->
           node_key = {type_id, concept_id, field_name}
-          {Map.put(nodes, node_key, parse_node(value)), meta, effects}
+          node = parse_node(value)
+          warn_missing_node_fields(node, node_key)
+          {Map.put(nodes, node_key, node), meta, effects}
 
         true ->
           {nodes, Map.put(meta, field_name, value), effects}
@@ -273,6 +281,25 @@ defmodule ExTTRPGDev.RuleSystem.Loader do
   defp parse_node(%{"formula" => formula}) do
     %{type: :formula, formula: formula}
   end
+
+  defp warn_missing_node_fields(%{type: :generated, method: nil}, {type_id, concept_id, field}) do
+    Logger.warning(
+      "Node #{inspect(field)} on #{inspect(type_id)} concept #{inspect(concept_id)} " <>
+        "has type :generated but is missing required field \"method\"."
+    )
+  end
+
+  defp warn_missing_node_fields(%{type: :mapping} = node, {type_id, concept_id, field}) do
+    for {key, label} <- [{:input, "input"}, {:steps, "steps"}],
+        is_nil(Map.get(node, key)) do
+      Logger.warning(
+        "Node #{inspect(field)} on #{inspect(type_id)} concept #{inspect(concept_id)} " <>
+          "has type :mapping but is missing required field #{inspect(label)}."
+      )
+    end
+  end
+
+  defp warn_missing_node_fields(_, _), do: :ok
 
   defp parse_rolling_method(fields) do
     %{

--- a/apps/ex_ttrpg_dev/lib/rule_system/rule_module.ex
+++ b/apps/ex_ttrpg_dev/lib/rule_system/rule_module.ex
@@ -81,15 +81,14 @@ defmodule ExTTRPGDev.RuleSystem.RuleModule do
   Returns `{:ok, %RuleModule{}}` on success or `{:error, reason}` on failure.
   """
   def from_map(%{"module" => module_map} = map) do
-    missing = Enum.find(@required_keys, fn key -> not Map.has_key?(module_map, key) end)
+    concept_types_raw = Map.get(map, "concept_type", [])
+    metadata_contributions_raw = Map.get(map, "metadata_contributions", [])
 
-    if missing do
-      {:error, {:missing_required_key, missing}}
-    else
+    with nil <- Enum.find(@required_keys, &(not Map.has_key?(module_map, &1))),
+         :ok <- validate_concept_types(concept_types_raw),
+         :ok <- validate_metadata_contributions(metadata_contributions_raw) do
       concept_types =
-        map
-        |> Map.get("concept_type", [])
-        |> Enum.map(fn et ->
+        Enum.map(concept_types_raw, fn et ->
           %ConceptType{
             id: et["id"],
             name: et["name"],
@@ -116,9 +115,7 @@ defmodule ExTTRPGDev.RuleSystem.RuleModule do
         end
 
       metadata_contributions =
-        map
-        |> Map.get("metadata_contributions", [])
-        |> Enum.map(&parse_metadata_contribution/1)
+        Enum.map(metadata_contributions_raw, &parse_metadata_contribution/1)
 
       {:ok,
        %__MODULE__{
@@ -135,10 +132,35 @@ defmodule ExTTRPGDev.RuleSystem.RuleModule do
          metadata_contributions: metadata_contributions,
          custom_metadata_keys: Map.get(module_map, "custom_metadata_keys", [])
        }}
+    else
+      missing when is_binary(missing) -> {:error, {:missing_required_key, missing}}
+      error -> error
     end
   end
 
   def from_map(_), do: {:error, {:missing_required_key, "module"}}
+
+  defp validate_concept_types(list) do
+    case Enum.find_index(list, fn et -> is_nil(et["id"]) end) do
+      nil -> :ok
+      idx -> {:error, {:concept_type_missing_id, idx}}
+    end
+  end
+
+  defp validate_metadata_contributions(list) do
+    list
+    |> Enum.with_index()
+    |> Enum.find_value(:ok, &check_metadata_contribution_fields/1)
+  end
+
+  defp check_metadata_contribution_fields({mc, idx}) do
+    required = ~w(from_type from_field to_type to_field value)
+
+    case Enum.find(required, &is_nil(mc[&1])) do
+      nil -> nil
+      field -> {:error, {:metadata_contribution_missing_field, field, idx}}
+    end
+  end
 
   defp parse_metadata_contribution(mc) do
     label_filters =

--- a/apps/ex_ttrpg_dev/test/rule_system/loader_test.exs
+++ b/apps/ex_ttrpg_dev/test/rule_system/loader_test.exs
@@ -610,6 +610,17 @@ defmodule ExTTRPGDev.RuleSystem.LoaderTest do
     """)
   end
 
+  # Writes a single concept TOML file to a fresh tmp system and returns the
+  # captured log output from loading it. Used by warning-assertion tests that
+  # exercise a single concept in isolation.
+  defp capture_load_with_concept(type_id, filename, toml) do
+    with_tmp_system([type_id], fn dir ->
+      File.mkdir_p!(Path.join(dir, "concepts/#{type_id}"))
+      File.write!(Path.join(dir, "concepts/#{type_id}/#{filename}.toml"), toml)
+      capture_log(fn -> Loader.load!(dir) end)
+    end)
+  end
+
   # --- Metadata key validation ---
 
   test "dnd_5e_srd loads with no unknown metadata key warnings" do
@@ -621,17 +632,11 @@ defmodule ExTTRPGDev.RuleSystem.LoaderTest do
 
   test "unknown top-level metadata key produces a warning" do
     log =
-      with_tmp_system(fn dir ->
-        File.mkdir_p!(Path.join(dir, "concepts/ability"))
-
-        File.write!(Path.join(dir, "concepts/ability/strength.toml"), """
-        [ability.strength]
-        name = "Strength"
-        bogus_field = "this should warn"
-        """)
-
-        capture_log(fn -> Loader.load!(dir) end)
-      end)
+      capture_load_with_concept("ability", "strength", """
+      [ability.strength]
+      name = "Strength"
+      bogus_field = "this should warn"
+      """)
 
     assert log =~ ~s(Unknown metadata key "bogus_field" on 1 "ability" concept)
     assert log =~ "strength"
@@ -640,18 +645,12 @@ defmodule ExTTRPGDev.RuleSystem.LoaderTest do
 
   test "structural vocabulary keys do not produce warnings" do
     log =
-      with_tmp_system(fn dir ->
-        File.mkdir_p!(Path.join(dir, "concepts/ability"))
-
-        File.write!(Path.join(dir, "concepts/ability/strength.toml"), """
-        [ability.strength]
-        name = "Strength"
-        level = 1
-        requires = []
-        """)
-
-        capture_log(fn -> Loader.load!(dir) end)
-      end)
+      capture_load_with_concept("ability", "strength", """
+      [ability.strength]
+      name = "Strength"
+      level = 1
+      requires = []
+      """)
 
     refute log =~ "Unknown metadata key"
   end
@@ -723,6 +722,43 @@ defmodule ExTTRPGDev.RuleSystem.LoaderTest do
       end)
 
     refute log =~ "Unknown metadata key"
+  end
+
+  # --- Required node field validation ---
+
+  test "generated node missing method produces a warning" do
+    log =
+      capture_load_with_concept("ability", "strength", """
+      [ability.strength]
+      name = "Strength"
+      base_score.type = "generated"
+      """)
+
+    assert log =~ ~s(Node "base_score" on "ability" concept "strength")
+    assert log =~ ~s(has type :generated but is missing required field "method")
+  end
+
+  test "mapping node missing input and steps produces warnings" do
+    log =
+      capture_load_with_concept("ability", "level", """
+      [ability.level]
+      name = "Level"
+      rank.type = "mapping"
+      """)
+
+    assert log =~ ~s(has type :mapping but is missing required field "input")
+    assert log =~ ~s(has type :mapping but is missing required field "steps")
+  end
+
+  test "rolling method missing dice produces a warning" do
+    log =
+      capture_load_with_concept("rolling_method", "broken", """
+      [rolling_method.broken]
+      name = "Broken Method"
+      drop = "lowest"
+      """)
+
+    assert log =~ ~s(Rolling method "broken" is missing required field "dice")
   end
 
   test "warnings group by key and type — one warning per (key, type_id) pair" do

--- a/apps/ex_ttrpg_dev/test/rule_system/rule_module_test.exs
+++ b/apps/ex_ttrpg_dev/test/rule_system/rule_module_test.exs
@@ -122,6 +122,28 @@ defmodule ExTTRPGDev.RuleSystem.RuleModuleTest do
     assert contrib.label_filters == []
   end
 
+  test "from_map/1 returns error when a concept_type entry is missing id" do
+    map = Map.put(@valid_map, "concept_type", [%{"name" => "Orphan"}])
+    assert {:error, {:concept_type_missing_id, 0}} = RuleModule.from_map(map)
+  end
+
+  test "from_map/1 returns error when a metadata_contribution entry is missing a required field" do
+    base = %{
+      "from_type" => "class",
+      "from_field" => "weapon_proficiencies",
+      "to_type" => "equipment",
+      "to_field" => "is_proficient",
+      "value" => 1
+    }
+
+    for field <- ~w(from_type from_field to_type to_field value) do
+      map = Map.put(@valid_map, "metadata_contributions", [Map.delete(base, field)])
+
+      assert {:error, {:metadata_contribution_missing_field, ^field, 0}} =
+               RuleModule.from_map(map)
+    end
+  end
+
   test "concept_type_ids/1 returns a MapSet of ids" do
     {:ok, pkg} = RuleModule.from_map(@valid_map)
     ids = RuleModule.concept_type_ids(pkg)


### PR DESCRIPTION
## Summary

- **Loader** (`feat(loader)`): Adds `warn_missing_node_fields/2` called after every node parse. Emits a `Logger.warning` naming the node `{type_id, concept_id, field_name}` when required fields are absent:
  - `:generated` nodes missing `"method"` — the evaluator cannot find a rolling method
  - `:mapping` nodes missing `"input"` or `"steps"` — the mapping lookup cannot run
  - Rolling methods missing `"dice"` — the dice parser crashes on first roll
- **RuleModule** (`feat(rule_module)`): `from_map/1` now validates concept type and metadata contribution lists before building the struct:
  - `[[concept_type]]` entry missing `id` → `{:error, {:concept_type_missing_id, idx}}`
  - `[[metadata_contributions]]` entry missing any of `from_type/from_field/to_type/to_field/value` → `{:error, {:metadata_contribution_missing_field, field, idx}}`
  - Restructured `from_map/1` from `if/else + with` to a flat `with/else` to fix a Credo nesting violation

Previously all of these failed silently (nil values, no effects generated, or runtime evaluator crash with no load-time signal).

## Test plan

- [x] All 66 tests pass
- [x] Loader: 3 new tests — generated node missing method, mapping node missing input/steps, rolling method missing dice
- [x] RuleModule: 2 new tests — concept_type missing id, metadata_contribution missing any required field (parameterized over all 5)

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added validation in loader.ex to warn about missing required fields in rolling methods (e.g., 'dice') and nodes (e.g., 'method' for generated type, 'input' and 'steps' for mapping type).</li>
<li>Refactored rule_module.ex to validate concept types and metadata contributions upfront, ensuring required fields like 'id' for concept types and 'from_type', 'from_field', 'to_type', 'to_field', 'value' for metadata contributions are present, returning errors if missing.</li>
<li>Added unit tests in loader_test.exs and rule_module_test.exs to verify the new validation logic and warning behaviors.</li>
</ul></div>