### PR TITLE
fix(expression): replace Code.eval_string with whitelisted expression evaluator

### DIFF
--- a/apps/ex_ttrpg_dev/lib/rule_system/expression.ex
+++ b/apps/ex_ttrpg_dev/lib/rule_system/expression.ex
@@ -5,8 +5,27 @@ defmodule ExTTRPGDev.RuleSystem.Expression do
   Formulas use the syntax `type('concept_id').field` to reference other nodes.
   For example: `floor((attr('dexterity').total_score - 10) / 2)`
 
-  These references create edges in the DAG. When evaluating, all references are
-  substituted with their resolved numeric values before expression evaluation.
+  These references create edges in the DAG. When evaluating, references are
+  resolved against the bindings map as part of expression evaluation.
+
+  ## Grammar
+
+  Formulas are parsed and evaluated against a closed grammar; they cannot
+  execute arbitrary code. Supported constructs:
+
+    * number literals — integers (`42`) and floats (`2.5`)
+    * boolean literals — `true`, `false`
+    * node references — `type('concept_id').field`
+    * arithmetic — `+`, `-`, `*`, `/` (`/` is float division; wrap in
+      `floor(...)` for integer results) and unary minus
+    * comparison — `>`, `<`, `>=`, `<=`, `==`, `!=` (numbers only)
+    * boolean logic — `and`, `or`, `not` (booleans only)
+    * grouping — `( ... )`
+    * functions — `floor/1`, `ceil/1`, `trunc/1`, `abs/1`, `min/2`, `max/2`
+
+  Anything outside this grammar returns `{:error, {:parse_error, message,
+  formula}}`; calling an unknown function returns `{:error, {:eval_error,
+  message, formula}}`.
   """
 
   @ref_pattern ~r/(\w+)\('([^']+)'\)\.(\w+)/
@@ -41,11 +60,11 @@ defmodule ExTTRPGDev.RuleSystem.Expression do
   @doc """
   Evaluates a formula string given a map of resolved node values.
 
-  Substitutes all `type('id').field` references in the formula with their
-  resolved numeric values from `bindings`, then evaluates the resulting
-  expression.
+  Node references in the formula are looked up in `bindings` (keyed by
+  `{type_id, concept_id, field_name}`), and the expression is evaluated
+  against the whitelisted grammar documented in the moduledoc.
 
-  Returns `{:ok, number}` or `{:error, reason}`.
+  Returns `{:ok, number | boolean}` or `{:error, reason}`.
 
   ## Examples
 
@@ -67,18 +86,342 @@ defmodule ExTTRPGDev.RuleSystem.Expression do
       {type_id, concept_id, field_name} = missing
       {:error, {:missing_binding, "#{type_id}('#{concept_id}').#{field_name}"}}
     else
-      processed =
-        Enum.reduce(bindings, formula, fn {{type_id, concept_id, field_name}, value}, acc ->
-          ref_str = "#{type_id}('#{concept_id}').#{field_name}"
-          String.replace(acc, ref_str, to_string(value))
-        end)
-
-      try do
-        {result, _bindings} = Code.eval_string(processed)
-        {:ok, result}
-      rescue
-        e -> {:error, {:eval_error, Exception.message(e), processed}}
+      with {:ok, ast} <- parse(formula),
+           {:ok, value} <- eval_ast(ast, bindings) do
+        {:ok, value}
+      else
+        {:error, {:parse_error, message}} -> {:error, {:parse_error, message, formula}}
+        {:error, {:eval_error, message}} -> {:error, {:eval_error, message, formula}}
       end
     end
+  end
+
+  @doc """
+  Parses a formula string into an AST, without evaluating it.
+
+  Useful for validating formulas at load time. Returns `{:ok, ast}` or
+  `{:error, {:parse_error, message}}`.
+  """
+  def parse(formula) do
+    with {:ok, tokens} <- tokenize(formula),
+         {:ok, ast, []} <- parse_expr(tokens) do
+      {:ok, ast}
+    else
+      {:ok, _ast, [token | _]} ->
+        {:error, {:parse_error, "unexpected #{describe_token(token)} after expression"}}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  # --- Tokenizer ---
+
+  defp tokenize(input), do: tokenize(input, [])
+
+  defp tokenize("", acc), do: {:ok, Enum.reverse(acc)}
+
+  defp tokenize(input, acc) do
+    cond do
+      ws = leading_match(~r/^\s+/, input) ->
+        tokenize(chop(input, ws), acc)
+
+      ref = Regex.run(~r/^(\w+)\('([^']+)'\)\.(\w+)/, input) ->
+        [full, type_id, concept_id, field_name] = ref
+        tokenize(chop(input, full), [{:ref, {type_id, concept_id, field_name}} | acc])
+
+      number = leading_match(~r/^\d+(?:\.\d+)?/, input) ->
+        tokenize(chop(input, number), [{:number, parse_number(number)} | acc])
+
+      ident = leading_match(~r/^[A-Za-z_]\w*/, input) ->
+        tokenize(chop(input, ident), [ident_token(ident) | acc])
+
+      op = leading_match(~r/^(?:>=|<=|==|!=|[-+*\/(),<>])/, input) ->
+        tokenize(chop(input, op), [{:op, op} | acc])
+
+      true ->
+        {:error, {:parse_error, "unexpected character #{inspect(String.first(input))}"}}
+    end
+  end
+
+  defp leading_match(pattern, input) do
+    case Regex.run(pattern, input) do
+      [match | _] -> match
+      nil -> nil
+    end
+  end
+
+  defp chop(input, match),
+    do: binary_part(input, byte_size(match), byte_size(input) - byte_size(match))
+
+  defp parse_number(text) do
+    if String.contains?(text, "."), do: String.to_float(text), else: String.to_integer(text)
+  end
+
+  defp ident_token("true"), do: {:bool, true}
+  defp ident_token("false"), do: {:bool, false}
+  defp ident_token(keyword) when keyword in ~w[and or not], do: {:op, keyword}
+  defp ident_token(name), do: {:ident, name}
+
+  # --- Parser (recursive descent, lowest precedence first) ---
+
+  defp parse_expr(tokens), do: parse_or(tokens)
+
+  defp parse_or(tokens) do
+    parse_binary_chain(tokens, &parse_and/1, ["or"], :logic)
+  end
+
+  defp parse_and(tokens) do
+    parse_binary_chain(tokens, &parse_not/1, ["and"], :logic)
+  end
+
+  defp parse_not([{:op, "not"} | rest]) do
+    with {:ok, operand, rest} <- parse_not(rest) do
+      {:ok, {:not, operand}, rest}
+    end
+  end
+
+  defp parse_not(tokens), do: parse_comparison(tokens)
+
+  # Comparisons do not chain: `a > b > c` is a parse error (caught by the
+  # unconsumed-token check in parse/1), matching mathematical usage.
+  defp parse_comparison(tokens) do
+    with {:ok, left, rest} <- parse_additive(tokens) do
+      parse_comparison_rest(left, rest)
+    end
+  end
+
+  defp parse_comparison_rest(left, [{:op, op} | rest]) when op in ~w[> < >= <= == !=] do
+    with {:ok, right, rest} <- parse_additive(rest) do
+      {:ok, {:compare, op, left, right}, rest}
+    end
+  end
+
+  defp parse_comparison_rest(left, rest), do: {:ok, left, rest}
+
+  defp parse_additive(tokens) do
+    parse_binary_chain(tokens, &parse_multiplicative/1, ["+", "-"], :arith)
+  end
+
+  defp parse_multiplicative(tokens) do
+    parse_binary_chain(tokens, &parse_unary/1, ["*", "/"], :arith)
+  end
+
+  defp parse_binary_chain(tokens, next, ops, tag) do
+    with {:ok, left, rest} <- next.(tokens) do
+      parse_binary_chain_rest(left, rest, {next, ops, tag})
+    end
+  end
+
+  defp parse_binary_chain_rest(left, [{:op, op} | rest], {next, ops, tag} = level) do
+    if op in ops do
+      with {:ok, right, rest} <- next.(rest) do
+        parse_binary_chain_rest({tag, op, left, right}, rest, level)
+      end
+    else
+      {:ok, left, [{:op, op} | rest]}
+    end
+  end
+
+  defp parse_binary_chain_rest(left, rest, _level), do: {:ok, left, rest}
+
+  defp parse_unary([{:op, "-"} | rest]) do
+    with {:ok, operand, rest} <- parse_unary(rest) do
+      {:ok, {:negate, operand}, rest}
+    end
+  end
+
+  defp parse_unary(tokens), do: parse_primary(tokens)
+
+  defp parse_primary([{:number, n} | rest]), do: {:ok, {:number, n}, rest}
+  defp parse_primary([{:bool, b} | rest]), do: {:ok, {:bool, b}, rest}
+  defp parse_primary([{:ref, key} | rest]), do: {:ok, {:ref, key}, rest}
+
+  defp parse_primary([{:ident, name}, {:op, "("} | rest]) do
+    with {:ok, args, rest} <- parse_args(rest) do
+      {:ok, {:call, name, args}, rest}
+    end
+  end
+
+  defp parse_primary([{:ident, name} | _rest]) do
+    {:error, {:parse_error, "bare identifier #{inspect(name)} is not allowed"}}
+  end
+
+  defp parse_primary([{:op, "("} | rest]) do
+    with {:ok, expr, rest} <- parse_expr(rest) do
+      case rest do
+        [{:op, ")"} | rest] -> {:ok, expr, rest}
+        _ -> {:error, {:parse_error, "missing closing parenthesis"}}
+      end
+    end
+  end
+
+  defp parse_primary([token | _]) do
+    {:error, {:parse_error, "unexpected #{describe_token(token)}"}}
+  end
+
+  defp parse_primary([]) do
+    {:error, {:parse_error, "unexpected end of formula"}}
+  end
+
+  defp parse_args([{:op, ")"} | rest]), do: {:ok, [], rest}
+
+  defp parse_args(tokens) do
+    with {:ok, arg, rest} <- parse_expr(tokens) do
+      parse_args_rest(arg, rest)
+    end
+  end
+
+  defp parse_args_rest(arg, [{:op, ","} | rest]) do
+    with {:ok, args, rest} <- parse_args(rest) do
+      {:ok, [arg | args], rest}
+    end
+  end
+
+  defp parse_args_rest(arg, [{:op, ")"} | rest]), do: {:ok, [arg], rest}
+
+  defp parse_args_rest(_arg, _rest) do
+    {:error, {:parse_error, "expected ',' or ')' in argument list"}}
+  end
+
+  defp describe_token({:op, op}), do: "operator #{inspect(op)}"
+  defp describe_token({:ident, name}), do: "identifier #{inspect(name)}"
+  defp describe_token({:number, n}), do: "number #{n}"
+  defp describe_token({:bool, b}), do: "boolean #{b}"
+  defp describe_token({:ref, {t, c, f}}), do: "reference #{t}('#{c}').#{f}"
+
+  # --- Evaluator ---
+
+  defp eval_ast({:number, n}, _bindings), do: {:ok, n}
+  defp eval_ast({:bool, b}, _bindings), do: {:ok, b}
+
+  defp eval_ast({:ref, {type_id, concept_id, field_name} = key}, bindings) do
+    case Map.fetch(bindings, key) do
+      {:ok, value} ->
+        {:ok, value}
+
+      :error ->
+        {:error, {:eval_error, "unbound reference #{type_id}('#{concept_id}').#{field_name}"}}
+    end
+  end
+
+  defp eval_ast({:negate, operand}, bindings) do
+    with {:ok, value} <- eval_ast(operand, bindings) do
+      require_number(value, "-", &{:ok, -&1})
+    end
+  end
+
+  defp eval_ast({:not, operand}, bindings) do
+    with {:ok, value} <- eval_ast(operand, bindings) do
+      require_boolean(value, "not", &{:ok, not &1})
+    end
+  end
+
+  defp eval_ast({:arith, op, left, right}, bindings) do
+    with {:ok, l} <- eval_ast(left, bindings),
+         {:ok, r} <- eval_ast(right, bindings) do
+      apply_arithmetic(op, l, r)
+    end
+  end
+
+  defp eval_ast({:logic, op, left, right}, bindings) do
+    with {:ok, l} <- eval_ast(left, bindings) do
+      require_boolean(l, op, fn l -> eval_logical(op, l, right, bindings) end)
+    end
+  end
+
+  defp eval_ast({:compare, op, left, right}, bindings) do
+    with {:ok, l} <- eval_ast(left, bindings),
+         {:ok, r} <- eval_ast(right, bindings) do
+      apply_comparison(op, l, r)
+    end
+  end
+
+  defp eval_ast({:call, name, args}, bindings) do
+    with {:ok, values} <- eval_args(args, bindings) do
+      apply_function(name, values)
+    end
+  end
+
+  defp eval_args(args, bindings) do
+    Enum.reduce_while(args, {:ok, []}, fn arg, {:ok, acc} ->
+      case eval_ast(arg, bindings) do
+        {:ok, value} -> {:cont, {:ok, [value | acc]}}
+        {:error, _} = error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, values} -> {:ok, Enum.reverse(values)}
+      error -> error
+    end
+  end
+
+  # `and`/`or` short-circuit like their Elixir counterparts.
+  defp eval_logical("and", false, _right, _bindings), do: {:ok, false}
+  defp eval_logical("or", true, _right, _bindings), do: {:ok, true}
+
+  defp eval_logical(op, _l, right, bindings) do
+    with {:ok, r} <- eval_ast(right, bindings) do
+      require_boolean(r, op, &{:ok, &1})
+    end
+  end
+
+  defp apply_arithmetic(op, l, r) when is_number(l) and is_number(r) do
+    case op do
+      "+" -> {:ok, l + r}
+      "-" -> {:ok, l - r}
+      "*" -> {:ok, l * r}
+      "/" when r == 0 -> {:error, {:eval_error, "division by zero"}}
+      "/" -> {:ok, l / r}
+    end
+  end
+
+  defp apply_arithmetic(op, l, r) do
+    {:error,
+     {:eval_error, "#{inspect(op)} requires numbers, got: #{inspect(l)} and #{inspect(r)}"}}
+  end
+
+  defp apply_comparison(op, l, r) when is_number(l) and is_number(r) do
+    case op do
+      ">" -> {:ok, l > r}
+      "<" -> {:ok, l < r}
+      ">=" -> {:ok, l >= r}
+      "<=" -> {:ok, l <= r}
+      "==" -> {:ok, l == r}
+      "!=" -> {:ok, l != r}
+    end
+  end
+
+  defp apply_comparison(op, l, r) do
+    {:error,
+     {:eval_error, "#{inspect(op)} requires numbers, got: #{inspect(l)} and #{inspect(r)}"}}
+  end
+
+  defp apply_function("floor", [n]) when is_number(n), do: {:ok, floor(n)}
+  defp apply_function("ceil", [n]) when is_number(n), do: {:ok, ceil(n)}
+  defp apply_function("trunc", [n]) when is_number(n), do: {:ok, trunc(n)}
+  defp apply_function("abs", [n]) when is_number(n), do: {:ok, abs(n)}
+  defp apply_function("min", [a, b]) when is_number(a) and is_number(b), do: {:ok, min(a, b)}
+  defp apply_function("max", [a, b]) when is_number(a) and is_number(b), do: {:ok, max(a, b)}
+
+  defp apply_function(name, args) when name in ~w[floor ceil trunc abs min max] do
+    {:error,
+     {:eval_error, "#{name}/#{length(args)} expects numeric arguments, got: #{inspect(args)}"}}
+  end
+
+  defp apply_function(name, args) do
+    {:error, {:eval_error, "unknown function #{name}/#{length(args)}"}}
+  end
+
+  defp require_number(value, _op, fun) when is_number(value), do: fun.(value)
+
+  defp require_number(value, op, _fun) do
+    {:error, {:eval_error, "#{inspect(op)} requires a number, got: #{inspect(value)}"}}
+  end
+
+  defp require_boolean(value, _op, fun) when is_boolean(value), do: fun.(value)
+
+  defp require_boolean(value, op, _fun) do
+    {:error, {:eval_error, "#{inspect(op)} requires a boolean, got: #{inspect(value)}"}}
   end
 end

--- a/apps/ex_ttrpg_dev/test/rule_system/expression_test.exs
+++ b/apps/ex_ttrpg_dev/test/rule_system/expression_test.exs
@@ -81,5 +81,100 @@ defmodule ExTTRPGDev.RuleSystem.ExpressionTest do
       assert {:error, {:eval_error, _, _}} =
                Expression.evaluate("undefined_function_xyz()", %{})
     end
+
+    test "resolves refs sharing a prefix regardless of binding order" do
+      bindings = %{
+        {"attr", "strength", "mod"} => 100,
+        {"attr", "strength", "modifier"} => 3
+      }
+
+      assert {:ok, 103} =
+               Expression.evaluate("attr('strength').mod + attr('strength').modifier", bindings)
+
+      assert {:ok, 103} =
+               Expression.evaluate("attr('strength').modifier + attr('strength').mod", bindings)
+    end
+
+    test "supports unary minus on parenthesized expressions" do
+      bindings = %{{"ability", "dexterity", "modifier"} => 4}
+
+      assert {:ok, -2} =
+               Expression.evaluate("-(max(0, ability('dexterity').modifier - 2))", bindings)
+    end
+
+    test "supports ceil and trunc" do
+      assert {:ok, 3} = Expression.evaluate("ceil(5 / 2)", %{})
+      assert {:ok, 2} = Expression.evaluate("trunc(5 / 2)", %{})
+    end
+
+    test "supports min and abs" do
+      assert {:ok, 2} = Expression.evaluate("min(2, 5)", %{})
+      assert {:ok, 3} = Expression.evaluate("abs(0 - 3)", %{})
+    end
+
+    test "division produces floats; floor converts to integer" do
+      assert {:ok, 2.5} = Expression.evaluate("10 / 4", %{})
+      assert {:ok, 2} = Expression.evaluate("floor(10 / 4)", %{})
+    end
+
+    test "division by zero returns an error instead of raising" do
+      assert {:error, {:eval_error, message, _}} = Expression.evaluate("1 / 0", %{})
+      assert message =~ "division by zero"
+    end
+
+    test "evaluates boolean literals" do
+      assert {:ok, true} = Expression.evaluate("true", %{})
+      assert {:ok, false} = Expression.evaluate("false", %{})
+    end
+
+    test "evaluates comparisons and boolean logic" do
+      assert {:ok, false} = Expression.evaluate("1 > 2", %{})
+      assert {:ok, true} = Expression.evaluate("2 >= 2 and not false", %{})
+      assert {:ok, true} = Expression.evaluate("1 == 2 or 3 != 4", %{})
+    end
+
+    test "comparison against a ref value" do
+      bindings = %{{"character_trait", "character_level", "level"} => 5}
+
+      assert {:ok, true} =
+               Expression.evaluate("character_trait('character_level').level >= 5", bindings)
+    end
+
+    test "rejects module calls and atoms at parse time" do
+      assert {:error, {:parse_error, _, _}} =
+               Expression.evaluate(~s|System.cmd("rm", ["-rf", "/"])|, %{})
+
+      assert {:error, {:parse_error, _, _}} = Expression.evaluate(":os.cmd('id')", %{})
+      assert {:error, {:parse_error, _, _}} = Expression.evaluate("IO.puts(1)", %{})
+    end
+
+    test "rejects non-whitelisted functions at eval time" do
+      assert {:error, {:eval_error, message, _}} = Expression.evaluate("self()", %{})
+      assert message =~ "unknown function"
+    end
+
+    test "rejects bare identifiers" do
+      assert {:error, {:parse_error, _, _}} = Expression.evaluate("strength", %{})
+    end
+
+    test "rejects malformed syntax" do
+      assert {:error, {:parse_error, _, _}} = Expression.evaluate("1 + ", %{})
+      assert {:error, {:parse_error, _, _}} = Expression.evaluate("1 2", %{})
+      assert {:error, {:parse_error, _, _}} = Expression.evaluate("(1 + 2", %{})
+    end
+
+    test "arithmetic on booleans returns an error" do
+      assert {:error, {:eval_error, _, _}} = Expression.evaluate("true + 1", %{})
+    end
+  end
+
+  describe "parse/1" do
+    test "parses a valid formula" do
+      assert {:ok, _ast} = Expression.parse("floor((attr('dexterity').total_score - 10) / 2)")
+    end
+
+    test "returns a parse error for invalid syntax" do
+      assert {:error, {:parse_error, _}} = Expression.parse("1 +")
+    end
   end
 end


### PR DESCRIPTION
Closes #118

## Why

`Expression.evaluate/2` substituted resolved node values into the formula string and passed the result to `Code.eval_string`, which had three problems:

1. **Security** — formulas come from rule-system TOML, including third-party configs in `local_system_configs/`. A downloaded system could execute arbitrary Elixir (e.g. `System.cmd(...)`) at character-evaluation time.
2. **Correctness** — substitution iterated the full bindings map with `String.replace`, so refs sharing a prefix (`x('a').mod` vs `x('a').modifier`) corrupted each other, nondeterministically with map iteration order.
3. **Performance** — every node evaluation compiled Elixir source and paid one `String.replace` pass per resolved node in the system.

## What

Formulas are now tokenized and parsed into an AST (recursive descent) and evaluated against a closed grammar, documented in the moduledoc: number/boolean literals, node refs, arithmetic (`+ - * /`, unary minus), numeric comparisons, `and`/`or`/`not`, parentheses, and `floor`/`ceil`/`trunc`/`abs`/`min`/`max`. Refs resolve by direct map lookup, so prefix collisions are impossible and only refs present in the formula are touched.

Notable decisions (details in the commit message):
- Hand-rolled parser rather than a dep like `abacus` — the grammar is tiny, this is a published Hex library, and generic math-expression libs can't tokenize `type('id').field` refs, which would have forced keeping the substitution step that caused the collision bug.
- `/` stays float division with `floor()` for integer results, preserving existing formula behavior; division by zero returns an error tuple instead of raising.
- Unknown functions error at eval time tagged `:eval_error`, preserving the existing error contract.
- `parse/1` is public for future load-time formula validation (#122); `extract_refs/1` stays regex-based since Graph/Characters use it on ref-only strings (migration tracked in #124).

## Verification

- All 366 existing tests pass unchanged (including the pre-existing expression tests); 21 new expression tests cover the grammar, the prefix-collision regression, and code-execution rejection.
- All 122 unique expressions in the bundled dnd_5e_srd config parse, and the full 197-node DAG evaluates with unchanged results (STR 15 → +2 modifier).
- `mix credo`, `mix dialyzer`, and CodeScene delta all pass.


<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Replaced unsafe `Code.eval_string` with a custom parser and evaluator for formula expressions.</li>
<li>Implemented a restricted grammar supporting arithmetic, comparisons, boolean logic, and specific math functions.</li>
<li>Added robust error handling for parsing and evaluation, preventing arbitrary code execution.</li>
<li>Expanded test suite to cover new grammar features, edge cases, and security constraints.</li>
</ul></div>