### PR TITLE
fix(evaluator): make item-field substitution prefix-collision-safe

### DIFF
--- a/apps/ex_ttrpg_dev/lib/rule_system/evaluator.ex
+++ b/apps/ex_ttrpg_dev/lib/rule_system/evaluator.ex
@@ -107,9 +107,16 @@ defmodule ExTTRPGDev.RuleSystem.Evaluator do
     formula |> substitute_item_fields(item_fields) |> Expression.evaluate(resolved)
   end
 
+  # A single greedy-regex pass: `item.bonus_max` always matches its full
+  # field name, so fields sharing a prefix (item.bonus / item.bonus_max)
+  # cannot corrupt each other the way per-field String.replace passes did.
+  # Unknown fields are left untouched and surface as a parse error.
   defp substitute_item_fields(formula, item_fields) do
-    Enum.reduce(item_fields, formula, fn {name, value}, acc ->
-      String.replace(acc, "item.#{name}", to_string(value))
+    Regex.replace(~r/item\.(\w+)/, formula, fn full, name ->
+      case Map.fetch(item_fields, name) do
+        {:ok, value} -> to_string(value)
+        :error -> full
+      end
     end)
   end
 

--- a/apps/ex_ttrpg_dev/test/rule_system/evaluator_test.exs
+++ b/apps/ex_ttrpg_dev/test/rule_system/evaluator_test.exs
@@ -263,6 +263,39 @@ defmodule ExTTRPGDev.RuleSystem.EvaluatorTest do
       assert {:ok, resolved} = Evaluator.evaluate(system, generated, effects)
       assert resolved[{"attr", "strength", "total_score"}] == 18.0
     end
+
+    test "substitutes fields sharing a prefix regardless of map order" do
+      system = minimal_system()
+      generated = %{{"attr", "strength", "base_score"} => 16}
+
+      # "bonus" is a prefix of "bonus_max"; a per-field replace pass would
+      # corrupt "item.bonus_max" into "2_max" when "bonus" replaced first
+      effects = [
+        %{
+          target: {"attr", "strength", "total_score"},
+          value: "item.bonus + item.bonus_max",
+          item_fields: %{"bonus" => 2, "bonus_max" => 5}
+        }
+      ]
+
+      assert {:ok, resolved} = Evaluator.evaluate(system, generated, effects)
+      assert resolved[{"attr", "strength", "total_score"}] == 23
+    end
+
+    test "leaves unknown item fields unsubstituted, producing an error" do
+      system = minimal_system()
+      generated = %{{"attr", "strength", "base_score"} => 16}
+
+      effects = [
+        %{
+          target: {"attr", "strength", "total_score"},
+          value: "item.nonexistent * 2",
+          item_fields: %{"bonus" => 2}
+        }
+      ]
+
+      assert {:error, {:parse_error, _, _}} = Evaluator.evaluate(system, generated, effects)
+    end
   end
 
   describe "integration" do


### PR DESCRIPTION
Closes #119

## Why

`substitute_item_fields` ran one `String.replace` pass per item field over the effect formula. Fields sharing a prefix corrupted each other: with fields `bonus` and `bonus_max`, replacing `item.bonus` first turns `item.bonus_max` into `2_max` — nondeterministically, since the passes iterate a map. This is the same defect class as the ref substitution removed from `Expression` in #145, but in a separate code path.

## What

One `Regex.replace` pass over `item\.(\w+)`: the greedy `\w+` always consumes the full field name, so a prefix field can never match another field's text. Unknown fields are left untouched and surface as a parse error, preserving prior behavior (a dedicated friendlier error is #122's territory; parser-level item bindings would put a per-effect concern into the shared formula grammar and aren't worth it while effects are shapeless maps — #133).

## Verification

- New regression test: `item.bonus + item.bonus_max` with both fields bound resolves correctly (was corrupted before under adverse map order).
- New test: unknown `item.` field returns `{:error, {:parse_error, _, _}}` instead of silently misevaluating.
- Full suite (351 tests + doctests), credo, dialyzer, and CodeScene delta all pass.


<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored item field substitution to use a single regex pass instead of multiple String.replace calls.</li>
<li>Fixed a bug where fields sharing a prefix (e.g., 'bonus' and 'bonus_max') could cause incorrect substitution.</li>
<li>Added unit tests to verify correct substitution of prefixed fields and error handling for unknown fields.</li>
</ul></div>