### PR TITLE
fix(server): validate scoped resolve_choice like the build flow

### DIFF
--- a/apps/ttrpg_dev_cli/lib/cli/server.ex
+++ b/apps/ttrpg_dev_cli/lib/cli/server.ex
@@ -653,18 +653,12 @@ defmodule ExTTRPGDev.CLI.Server do
       character = Characters.load_character!(slug)
       system = RuleSystems.load_system!(character.metadata.rule_system)
 
-      choice_def =
-        get_in(system.concept_metadata, [{scope_type, scope_id}, "choices", choice_id]) ||
-          raise("unknown choice #{inspect(choice_id)} on #{scope_type}(#{scope_id})")
+      scope = {scope_type, scope_id}
+      choice_def = Serializer.fetch_choice_def!(system, scope, choice_id)
+      valid = Serializer.valid_sub_choices(system, scope, choice_def, character.decisions)
+      validate_concept_selection!(selection, valid)
 
-      options =
-        system.concept_metadata
-        |> Enum.filter(fn {{t, _id}, _} -> t == choice_def["type"] end)
-        |> Enum.map(fn {{_t, id}, _} -> id end)
-
-      validate_concept_selection!(selection, options)
-
-      decision = %{scope: {scope_type, scope_id}, choice: choice_id, selection: selection}
+      decision = %{scope: scope, choice: choice_id, selection: selection}
       updated = %{character | decisions: character.decisions ++ [decision]}
       Characters.save_character!(updated, true)
 

--- a/apps/ttrpg_dev_cli/test/cli/server_test.exs
+++ b/apps/ttrpg_dev_cli/test/cli/server_test.exs
@@ -495,6 +495,77 @@ defmodule ExTTRPGDev.CLI.ServerTest do
     end
   end
 
+  # ── resolve_choice scoped sub-choice validation ───────────────────────────────
+
+  describe "characters.resolve_choice scoped validation" do
+    setup do
+      # Build a Cleric so class/cleric sub-choices exist deterministically and
+      # start unresolved (the build flow does not auto-resolve sub-choices).
+      {start_resp, state1} =
+        Server.handle_command(
+          %{"command" => "characters.build_start", "system" => "dnd_5e_srd", "name" => "Vala"},
+          @initial_state
+        )
+
+      temp_id = start_resp.data.temp_id
+
+      state4 =
+        [{"class", "cleric"}, {"race", "human"}, {"background", "soldier"}]
+        |> Enum.reduce(state1, fn {type, id}, state ->
+          {resp, next_state} =
+            Server.handle_command(
+              %{
+                "command" => "characters.build_select",
+                "temp_id" => temp_id,
+                "concept_type" => type,
+                "concept_id" => id
+              },
+              state
+            )
+
+          assert resp.status == "ok"
+          next_state
+        end)
+
+      {finish_resp, _} =
+        Server.handle_command(
+          %{"command" => "characters.build_finish", "temp_id" => temp_id},
+          state4
+        )
+
+      assert finish_resp.status == "ok"
+      slug = finish_resp.data.slug
+      on_exit(fn -> Characters.delete_character(slug) end)
+
+      %{slug: slug}
+    end
+
+    defp resolve_cleric_skill(slug, choice, selection) do
+      run(%{
+        "command" => "characters.resolve_choice",
+        "character" => slug,
+        "scope_type" => "class",
+        "scope_id" => "cleric",
+        "choice" => choice,
+        "selection" => selection
+      }).status
+    end
+
+    test "rejects a selection outside the choice's options whitelist", %{slug: slug} do
+      # cleric skill_proficiency_1 whitelists 5 skills; athletics is a valid
+      # skill concept but not among them
+      assert resolve_cleric_skill(slug, "skill_proficiency_1", "athletics") == "error"
+    end
+
+    test "rejects an already-chosen selection for a same-type sibling choice", %{slug: slug} do
+      assert resolve_cleric_skill(slug, "skill_proficiency_1", "history") == "ok"
+      # same selection for the sibling same-type choice must be rejected...
+      assert resolve_cleric_skill(slug, "skill_proficiency_2", "history") == "error"
+      # ...while a different whitelisted selection is still accepted
+      assert resolve_cleric_skill(slug, "skill_proficiency_2", "insight") == "ok"
+    end
+  end
+
   # ── resolve_choice spell inventory integration ────────────────────────────────
 
   describe "characters.resolve_choice spell inventory" do


### PR DESCRIPTION
Closes #120

## Why

The saved-character variant of `characters.resolve_choice` (`server.ex:641`) built its valid-options list inline as *every* concept of the choice's type. Two constraints the build-time twin (`characters.build_resolve_sub`) already enforces were skipped:

1. the choice's explicit `options` whitelist — e.g. cleric `skill_proficiency_1` allows only 5 specific skills, but any skill concept was accepted;
2. already-chosen exclusion — the same selection could be recorded twice across same-type choices in the same scope (e.g. History for both cleric skill slots).

## What

The handler now runs the identical `Serializer.fetch_choice_def!` → `valid_sub_choices` → `validate_concept_selection!` sequence the build flow uses, deleting the duplicated inline lookup. No behavior change for valid selections.

## Verification

- New test: selection outside the whitelist (`athletics` for cleric skills) is rejected.
- New test: duplicate selection for a same-type sibling choice is rejected, while a different whitelisted selection still succeeds.
- Tests build a Cleric deterministically via the build flow — the random `characters.gen` fixture auto-resolves level-1 sub-choices and made the assertions flaky for randomly-rolled clerics (observed before switching).
- Full suite (298 + 55 tests), credo, dialyzer, CodeScene delta all pass; server tests ran 3× stable.

Noted for later: the handler still doesn't verify the character owns the scope concept — pre-existing behavior shared with the build flow, tracked as part of #131 (move choice resolution into the library).


<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored character choice resolution to use Serializer helper methods for fetching definitions and validating sub-choices.</li>
<li>Improved validation logic to correctly handle scoped sub-choice whitelists and prevent duplicate selections for same-type sibling choices.</li>
<li>Added comprehensive unit tests for scoped sub-choice validation, covering whitelist enforcement and duplicate selection prevention.</li>
</ul></div>