### PR TITLE
fix(cli): harden REPL interactive input and panic paths

### DIFF
--- a/cli/src/commands/characters.rs
+++ b/cli/src/commands/characters.rs
@@ -447,13 +447,23 @@ fn select_pending_choice(choices: &[PendingChoice]) -> Option<&PendingChoice> {
     for (i, c) in choices.iter().enumerate() {
         println!("  {}: {}", i + 1, c.name);
     }
-    let idx = prompt_integer("Select choice (number):")? as usize;
-    match choices.get(idx.saturating_sub(1)) {
-        Some(c) => Some(c),
+    let idx = prompt_integer("Select choice (number):")?;
+    match selection_index(idx, choices.len()) {
+        Some(i) => Some(&choices[i]),
         None => {
             eprintln!("Invalid selection.");
             None
         }
+    }
+}
+
+/// Maps 1-based user input onto a 0-based index, rejecting anything outside
+/// `1..=len` (notably `0`, which `saturating_sub` used to alias to entry 1).
+fn selection_index(input: i64, len: usize) -> Option<usize> {
+    if input >= 1 && (input as usize) <= len {
+        Some(input as usize - 1)
+    } else {
+        None
     }
 }
 
@@ -744,14 +754,43 @@ fn prompt_choice_value(choice: &PendingChoice, engine: &mut Engine) -> Option<(i
 
     let roll_req = json!({"command": "roll", "dice": format!("1{die}")});
     match engine.call::<_, RollResult>(&roll_req) {
-        Ok(result) => {
-            let rolled = result.results[0].total;
-            println!("Rolled: {rolled}");
-            Some((rolled, "rolled".to_string()))
-        }
+        Ok(result) => match result.results.first() {
+            Some(first) => {
+                let rolled = first.total;
+                println!("Rolled: {rolled}");
+                Some((rolled, "rolled".to_string()))
+            }
+            None => {
+                eprintln!("Error rolling: engine returned no results.");
+                None
+            }
+        },
         Err(e) => {
             eprintln!("Error rolling: {e}");
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::selection_index;
+
+    #[test]
+    fn selection_index_accepts_the_full_valid_range() {
+        assert_eq!(selection_index(1, 3), Some(0));
+        assert_eq!(selection_index(3, 3), Some(2));
+    }
+
+    #[test]
+    fn selection_index_rejects_zero() {
+        // 0 used to alias to entry 1 via saturating_sub
+        assert_eq!(selection_index(0, 3), None);
+    }
+
+    #[test]
+    fn selection_index_rejects_out_of_range_and_negative_input() {
+        assert_eq!(selection_index(4, 3), None);
+        assert_eq!(selection_index(-1, 3), None);
     }
 }

--- a/cli/src/repl.rs
+++ b/cli/src/repl.rs
@@ -96,7 +96,9 @@ impl CommandCompleter {
         req: serde_json::Value,
     ) -> Option<T> {
         let engine = self.engine.as_ref()?;
-        engine.lock().unwrap().call::<_, T>(&req).ok()
+        // A poisoned lock degrades completion to no-suggestions rather than
+        // panicking inside reedline's event loop.
+        engine.lock().ok()?.call::<_, T>(&req).ok()
     }
 
     fn fetch_character_slugs(&self) -> Vec<String> {
@@ -226,6 +228,15 @@ pub fn run() {
     run_reedline(engine, &mut display_mode);
 }
 
+/// Locks the engine, recovering from a poisoned mutex: the REPL is
+/// single-threaded, so the engine state behind a poisoned lock is still
+/// consistent and continuing beats crashing the session.
+fn lock_engine(engine: &Arc<Mutex<Engine>>) -> std::sync::MutexGuard<'_, Engine> {
+    engine
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
 fn run_pipe(engine: Arc<Mutex<Engine>>, display_mode: &mut DisplayMode) {
     use std::io::BufRead;
     loop {
@@ -237,7 +248,7 @@ fn run_pipe(engine: Arc<Mutex<Engine>>, display_mode: &mut DisplayMode) {
                 if trimmed.is_empty() {
                     continue;
                 }
-                if !handle_line(&trimmed, &mut engine.lock().unwrap(), display_mode) {
+                if !handle_line(&trimmed, &mut lock_engine(&engine), display_mode) {
                     println!("Goodbye!");
                     break;
                 }
@@ -282,7 +293,7 @@ fn run_reedline(engine: Arc<Mutex<Engine>>, display_mode: &mut DisplayMode) {
                 if trimmed.is_empty() {
                     continue;
                 }
-                if !handle_line(trimmed, &mut engine.lock().unwrap(), display_mode) {
+                if !handle_line(trimmed, &mut lock_engine(&engine), display_mode) {
                     println!("Goodbye!");
                     break;
                 }


### PR DESCRIPTION
Closes #121

## What

1. **Zero/out-of-range selection** — entering `0` at "Select choice (number)" went through `saturating_sub(1)` and silently resolved choice **1**. Range validation now lives in a `selection_index` helper that rejects anything outside `1..=len`, with unit tests covering `0`, negative, boundary, and out-of-range inputs.
2. **Empty-results panic** — `result.results[0].total` in the HP-roll flow was the only unchecked index on protocol data; an empty `results` array from the engine panicked the REPL mid-build. It now prints an error and aborts the choice.
3. **Poisoned-mutex panics** — the tab completer's `lock().unwrap()` now degrades to no-suggestions via `lock().ok()?`; the two main-loop lock sites recover with `PoisonError::into_inner` (the REPL is single-threaded, so the state behind a poisoned lock is consistent).

Kept the `Mutex` rather than restructuring to `Rc<RefCell<Engine>>` to keep the diff small — that can ride along with the `commands/build.rs` split (#142).

## Verification

- 3 new unit tests for `selection_index`; full `cargo test` passes (38 unit + 4 PTY workflow tests, which drive the real engine binary).
- `cargo fmt` and `cargo clippy` clean for the changed files (the one clippy warning, `items_after_test_module` in `display.rs`, is pre-existing and tracked in #143).
- Pipe-mode smoke test through the new `lock_engine` path starts and exits cleanly.


<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored user selection logic in characters.rs to use a dedicated selection_index function, correctly handling 1-based input and rejecting invalid values like 0.</li>
<li>Added unit tests for the new selection_index function to ensure correct range validation.</li>
<li>Improved robustness in characters.rs by adding a check for empty results when rolling dice.</li>
<li>Enhanced REPL stability by implementing a lock_engine helper that recovers from poisoned mutexes instead of panicking.</li>
<li>Updated REPL command completion and execution paths to use the new lock_engine helper.</li>
</ul></div>