### PR TITLE
fix(loader): surface config errors instead of silently ignoring or crashing

### DIFF
--- a/apps/ex_ttrpg_dev/lib/rule_system/graph.ex
+++ b/apps/ex_ttrpg_dev/lib/rule_system/graph.ex
@@ -181,7 +181,12 @@ defmodule ExTTRPGDev.RuleSystem.Graph do
     end
   end
 
-  defp add_single_effect_edge(graph, _nodes, _effect), do: {:ok, graph}
+  # The Loader only emits tuple targets (unparseable ones are warned about
+  # and dropped at load time), so anything else reaching this point is a
+  # caller bug worth rejecting rather than silently ignoring.
+  defp add_single_effect_edge(_graph, _nodes, %{target: target}) do
+    {:error, {:invalid_effect_target, target}}
+  end
 
   defp add_formula_effect_edge(graph, nodes, target_key, value) when is_binary(value) do
     validate_and_add_refs(graph, nodes, value, target_key)

--- a/apps/ex_ttrpg_dev/lib/rule_system/loader.ex
+++ b/apps/ex_ttrpg_dev/lib/rule_system/loader.ex
@@ -127,8 +127,8 @@ defmodule ExTTRPGDev.RuleSystem.Loader do
   @doc "Loads a rule system directory, returning `{:ok, data}` or `{:error, reason}`."
   def load(path) do
     with {:ok, rule_module} <- load_module(path),
-         {:ok, data} <- load_concept_files(path, rule_module) do
-      inventory_rules = load_inventory_rules(path)
+         {:ok, data} <- load_concept_files(path, rule_module),
+         {:ok, inventory_rules} <- load_inventory_rules(path) do
       data = expand_metadata_contributions(data, rule_module)
       warn_unknown_metadata_keys(data.concept_metadata, rule_module, inventory_rules)
       {:ok, data |> Map.put(:module, rule_module) |> Map.put(:inventory_rules, inventory_rules)}
@@ -144,45 +144,76 @@ defmodule ExTTRPGDev.RuleSystem.Loader do
   end
 
   defp load_module(path) do
+    with {:ok, rule_module} <- parse_module_file(path),
+         {:ok, choices} <- load_character_building_choices(path) do
+      {:ok, %{rule_module | character_building_choices: choices}}
+    end
+  end
+
+  defp parse_module_file(path) do
     module_path = Path.join(path, @module_file)
 
     with {:ok, contents} <- File.read(module_path),
          {:ok, map} <- TomlElixir.decode(contents),
          {:ok, rule_module} <- RuleModule.from_map(map) do
-      {:ok, %{rule_module | character_building_choices: load_character_building_choices(path)}}
+      {:ok, rule_module}
     else
       {:error, reason} -> {:error, {:module_parse_error, reason}}
     end
   end
 
+  # A missing file is fine (the system has no inventory rules); any other
+  # failure — unreadable file, TOML syntax error, validation error from
+  # InventoryRules.from_map — must surface, not silently yield an empty
+  # default.
   defp load_inventory_rules(path) do
     rules_path = Path.join(path, @inventory_rules_file)
 
-    with {:ok, contents} <- File.read(rules_path),
-         {:ok, map} <- TomlElixir.decode(contents),
-         {:ok, rules} <- InventoryRules.from_map(map) do
-      rules
-    else
-      _ -> %InventoryRules{}
+    case File.read(rules_path) do
+      {:error, :enoent} ->
+        {:ok, %InventoryRules{}}
+
+      {:error, reason} ->
+        {:error, {:inventory_rules_error, reason}}
+
+      {:ok, contents} ->
+        with {:ok, map} <- TomlElixir.decode(contents),
+             {:ok, rules} <- InventoryRules.from_map(map) do
+          {:ok, rules}
+        else
+          {:error, reason} -> {:error, {:inventory_rules_error, reason}}
+        end
     end
   end
 
+  # Same policy as load_inventory_rules: only a missing file falls back.
   defp load_character_building_choices(path) do
     building_path = Path.join(path, @character_building_file)
 
-    with {:ok, contents} <- File.read(building_path),
-         {:ok, map} <- TomlElixir.decode(contents) do
-      map
-      |> Map.get("character_choice", [])
-      |> Enum.map(fn cc ->
-        %RuleModule.CharacterChoice{
-          concept_type: cc["concept_type"],
-          required: Map.get(cc, "required", true)
-        }
-      end)
-    else
-      _ -> []
+    case File.read(building_path) do
+      {:error, :enoent} ->
+        {:ok, []}
+
+      {:error, reason} ->
+        {:error, {:character_building_error, reason}}
+
+      {:ok, contents} ->
+        case TomlElixir.decode(contents) do
+          {:ok, map} -> {:ok, parse_character_choices(map)}
+          {:error, reason} -> {:error, {:character_building_error, reason}}
+        end
     end
+  end
+
+  defp parse_character_choices(map) do
+    map
+    |> Map.get("character_choice", [])
+    |> Enum.map(fn cc ->
+      %RuleModule.CharacterChoice{
+        concept_type: cc["concept_type"],
+        required: Map.get(cc, "required", true)
+      }
+    end)
   end
 
   defp load_concept_files(path, rule_module) do
@@ -250,20 +281,31 @@ defmodule ExTTRPGDev.RuleSystem.Loader do
       cond do
         field_name == "contributes" and is_list(value) ->
           new_effects =
-            Enum.map(value, &parse_effect({type_id, concept_id}, &1))
+            value
+            |> Enum.map(&parse_effect({type_id, concept_id}, &1))
+            |> Enum.reject(&is_nil/1)
 
           {nodes, Map.put(meta, field_name, value), effects ++ new_effects}
 
         is_map(value) and (Map.has_key?(value, "type") or Map.has_key?(value, "formula")) ->
-          node_key = {type_id, concept_id, field_name}
-          node = parse_node(value)
-          warn_missing_node_fields(node, node_key)
-          {Map.put(nodes, node_key, node), meta, effects}
+          {add_parsed_node(nodes, {type_id, concept_id, field_name}, value), meta, effects}
 
         true ->
           {nodes, Map.put(meta, field_name, value), effects}
       end
     end)
+  end
+
+  defp add_parsed_node(nodes, node_key, value) do
+    case parse_node(value) do
+      nil ->
+        warn_unknown_node_type(value, node_key)
+        nodes
+
+      node ->
+        warn_missing_node_fields(node, node_key)
+        Map.put(nodes, node_key, node)
+    end
   end
 
   defp parse_node(%{"type" => "generated"} = map) do
@@ -280,6 +322,19 @@ defmodule ExTTRPGDev.RuleSystem.Loader do
 
   defp parse_node(%{"formula" => formula}) do
     %{type: :formula, formula: formula}
+  end
+
+  # Unrecognized node definition (e.g. a typo'd "type" value with no
+  # "formula" key). The caller warns and skips the node instead of this
+  # clause head raising FunctionClauseError.
+  defp parse_node(_), do: nil
+
+  defp warn_unknown_node_type(value, {type_id, concept_id, field}) do
+    Logger.warning(
+      "Node #{inspect(field)} on #{inspect(type_id)} concept #{inspect(concept_id)} " <>
+        "has unrecognized type #{inspect(value["type"])}; expected \"generated\", " <>
+        "\"accumulator\", \"mapping\", or a \"formula\" key. Node skipped."
+    )
   end
 
   defp warn_missing_node_fields(%{type: :generated, method: nil}, {type_id, concept_id, field}) do
@@ -328,7 +383,9 @@ defmodule ExTTRPGDev.RuleSystem.Loader do
   end
 
   defp expand_source_values(concept_metadata, contribution, source_id, meta) do
-    values = Map.get(meta, contribution.from_field, [])
+    # List.wrap: a scalar value (`languages = "Common"`) is treated as a
+    # single-element list instead of crashing the flat_map.
+    values = meta |> Map.get(contribution.from_field) |> List.wrap()
 
     Enum.flat_map(values, fn val ->
       targets = find_contribution_targets(concept_metadata, contribution, val)
@@ -423,12 +480,34 @@ defmodule ExTTRPGDev.RuleSystem.Loader do
   end
 
   defp parse_effect(source, %{"target" => target, "value" => value} = entry) do
-    parsed_target =
-      case Regex.run(~r/(\w+)\('([^']+)'\)\.(\w+)/, target) do
-        [_, type_id, concept_id, field_name] -> {type_id, concept_id, field_name}
-        _ -> target
-      end
+    case Regex.run(~r/(\w+)\('([^']+)'\)\.(\w+)/, target) do
+      [_, type_id, concept_id, field_name] ->
+        %{
+          source: source,
+          target: {type_id, concept_id, field_name},
+          value: value,
+          when: Map.get(entry, "when")
+        }
 
-    %{source: source, target: parsed_target, value: value, when: Map.get(entry, "when")}
+      _ ->
+        {source_type, source_id} = source
+
+        Logger.warning(
+          "Contribution on #{inspect(source_type)} concept #{inspect(source_id)} has " <>
+            "unparseable target #{inspect(target)}; expected \"type('id').field\". " <>
+            "Effect skipped."
+        )
+
+        nil
+    end
+  end
+
+  defp parse_effect({source_type, source_id}, entry) do
+    Logger.warning(
+      "Contribution on #{inspect(source_type)} concept #{inspect(source_id)} is missing " <>
+        "required key(s) \"target\" and/or \"value\": #{inspect(entry)}. Effect skipped."
+    )
+
+    nil
   end
 end

--- a/apps/ex_ttrpg_dev/test/rule_system/graph_test.exs
+++ b/apps/ex_ttrpg_dev/test/rule_system/graph_test.exs
@@ -35,6 +35,13 @@ defmodule ExTTRPGDev.RuleSystem.GraphTest do
     assert map_size(system.nodes) == 3
   end
 
+  test "build/1 rejects a non-tuple effect target" do
+    effect = %{source: {"attr", "strength"}, target: "attr(strength).total_score", value: 2}
+    data = Map.put(minimal_loader_data(), :effects, [effect])
+
+    assert {:error, {:invalid_effect_target, "attr(strength).total_score"}} = Graph.build(data)
+  end
+
   test "build/1 returns error for undefined reference" do
     bad_data = %{
       nodes: %{

--- a/apps/ex_ttrpg_dev/test/rule_system/loader_test.exs
+++ b/apps/ex_ttrpg_dev/test/rule_system/loader_test.exs
@@ -783,4 +783,123 @@ defmodule ExTTRPGDev.RuleSystem.LoaderTest do
     assert occurrences == 1, "Expected one grouped warning for 'bogus', got #{occurrences}"
     assert log =~ "2 \"ability\" concepts"
   end
+
+  # --- Config error surfacing ---
+
+  # Loads a tmp system containing a single concept file and returns
+  # {captured_log, loaded_data} so tests can assert on both.
+  defp load_and_capture(type_id, filename, toml) do
+    with_tmp_system([type_id], fn dir ->
+      File.mkdir_p!(Path.join(dir, "concepts/#{type_id}"))
+      File.write!(Path.join(dir, "concepts/#{type_id}/#{filename}.toml"), toml)
+
+      log =
+        capture_log(fn ->
+          send(self(), {:loaded, Loader.load!(dir)})
+        end)
+
+      assert_received {:loaded, data}
+      {log, data}
+    end)
+  end
+
+  test "unparseable contributes target warns and skips the effect" do
+    {log, data} =
+      load_and_capture("ability", "strength", """
+      [ability.strength]
+      name = "Strength"
+      contributes = [{target = "ability(dexterity).total_score", value = 2}]
+      """)
+
+    assert data.effects == []
+    assert log =~ "unparseable target"
+    assert log =~ ~s{"ability(dexterity).total_score"}
+  end
+
+  test "contributes entry missing target or value warns and skips the effect" do
+    {log, data} =
+      load_and_capture("ability", "strength", """
+      [ability.strength]
+      name = "Strength"
+      contributes = [{target = "ability('dexterity').total_score"}]
+      """)
+
+    assert data.effects == []
+    assert log =~ ~s{missing required key(s) "target" and/or "value"}
+    assert log =~ "strength"
+  end
+
+  test "unrecognized node type warns and skips the node instead of crashing" do
+    {log, data} =
+      load_and_capture("ability", "strength", """
+      [ability.strength]
+      name = "Strength"
+      score.type = "formual"
+      """)
+
+    refute Map.has_key?(data.nodes, {"ability", "strength", "score"})
+    assert log =~ ~s(unrecognized type "formual")
+    assert log =~ "Node skipped"
+  end
+
+  test "malformed inventory_rules.toml propagates an error instead of an empty default" do
+    with_tmp_system(fn dir ->
+      File.write!(Path.join(dir, "inventory_rules.toml"), "this is [not valid toml")
+      assert {:error, {:inventory_rules_error, _}} = Loader.load(dir)
+    end)
+  end
+
+  test "malformed character_building.toml propagates an error" do
+    with_tmp_system(fn dir ->
+      File.write!(Path.join(dir, "character_building.toml"), "this is [not valid toml")
+      assert {:error, {:character_building_error, _}} = Loader.load(dir)
+    end)
+  end
+
+  test "scalar metadata_contributions from_field value is treated as a single-element list" do
+    data =
+      with_tmp_system(["class", "equipment"], fn dir ->
+        File.write!(Path.join(dir, "module.toml"), """
+        [module]
+        name = "Test System"
+        slug = "test_system"
+        version = "0.0.1"
+
+        [[concept_type]]
+        id = "class"
+        name = "Class"
+
+        [[concept_type]]
+        id = "equipment"
+        name = "Equipment"
+
+        [[metadata_contributions]]
+        from_type = "class"
+        from_field = "weapon_proficiencies"
+        to_type = "equipment"
+        to_field = "is_proficient"
+        value = 1
+        label_filters = []
+        """)
+
+        File.mkdir_p!(Path.join(dir, "concepts/class"))
+        File.mkdir_p!(Path.join(dir, "concepts/equipment"))
+
+        File.write!(Path.join(dir, "concepts/class/fighter.toml"), """
+        [class.fighter]
+        name = "Fighter"
+        weapon_proficiencies = "Longsword"
+        """)
+
+        File.write!(Path.join(dir, "concepts/equipment/longsword.toml"), """
+        [equipment.longsword]
+        name = "Longsword"
+        """)
+
+        Loader.load!(dir)
+      end)
+
+    assert [effect] = data.effects
+    assert effect.target == {"equipment", "longsword", "is_proficient"}
+  end
 end


### PR DESCRIPTION
Closes #122

## Why

Several loader paths made malformed config invisible or crashed with raw exceptions, undercutting the load-time validation direction of the last few loader PRs. Worst was the silent one: a typo'd `contributes` target (`"ability(strength).total"`, missing quotes) stayed a raw string, slid through Graph's catch-all, never matched anything in the Evaluator — and the effect just didn't exist, with no signal.

## What

| Path | Before | After |
|---|---|---|
| Unparseable `contributes` target | silent no-op effect | warning (source concept + target string), effect dropped |
| `contributes` entry missing `target`/`value` | `FunctionClauseError` | warning, effect dropped |
| Non-tuple target reaching Graph | silently ignored | `{:error, {:invalid_effect_target, t}}` |
| Unknown node `type` (`"formual"`) | `FunctionClauseError` | warning with field path + expected types, node skipped |
| Malformed `inventory_rules.toml` / `character_building.toml` | silently loaded empty defaults | `{:error, {:inventory_rules_error, _}}` / `{:error, {:character_building_error, _}}`; only missing files fall back |
| Scalar `from_field` value (`languages = "Common"`) | `Protocol.UndefinedError` | wrapped as single-element list |

The warn-and-skip vs. halt split follows the loader's existing posture: concept-level authoring mistakes warn and degrade (like missing node fields today), whole-file failures halt the load (like concept TOML syntax errors today). **Note one deliberate behavior change:** a system with a malformed `inventory_rules.toml` previously loaded without inventory rules; it now fails to load.

## Verification

- Six new loader tests (one per row above) plus a Graph rejection test.
- The existing "dnd_5e_srd loads with zero warnings" test still passes, so valid configs gain no noise.
- Full suite (305 + 55 tests), credo, dialyzer, CodeScene delta all pass.


<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated `add_single_effect_edge` in `Graph` to return an error for invalid effect targets instead of silently ignoring them.</li>
<li>Refactored `Loader.load` to properly handle errors during `load_inventory_rules` instead of defaulting to an empty state.</li>
<li>Updated `load_inventory_rules` and `load_character_building_choices` to distinguish between missing files (which are allowed) and parsing/validation errors (which are now surfaced).</li>
<li>Improved error propagation in `load_module` by separating module file parsing from character building choices loading.</li>
</ul></div>