### PR TITLE
fix(character): resolve default rolling method from config, not "standard"

### DIFF
--- a/apps/ex_ttrpg_dev/lib/characters/character.ex
+++ b/apps/ex_ttrpg_dev/lib/characters/character.ex
@@ -223,7 +223,7 @@ defmodule ExTTRPGDev.Characters.Character do
   defp item_from_spec(_, _), do: []
 
   defp roll_generated_value(%{method: method_id}, rolling_methods) do
-    method = Map.get(rolling_methods, method_id || "standard")
+    method = resolve_rolling_method(method_id, rolling_methods)
     rolls = Dice.roll(method.dice)
 
     rolls =
@@ -234,6 +234,22 @@ defmodule ExTTRPGDev.Characters.Character do
       end
 
     Enum.sum(rolls)
+  end
+
+  defp resolve_rolling_method(nil, rolling_methods) do
+    case Enum.find(rolling_methods, fn {_id, method} -> method.default end) do
+      {_id, method} ->
+        method
+
+      nil ->
+        raise "generated node has no rolling method and no rolling method declares " <>
+                "default = true; set one or add an explicit \"method\" to the node"
+    end
+  end
+
+  defp resolve_rolling_method(method_id, rolling_methods) do
+    Map.get(rolling_methods, method_id) ||
+      raise "unknown rolling method #{inspect(method_id)}"
   end
 
   defp slugify(name) do

--- a/apps/ex_ttrpg_dev/lib/rule_system/loader.ex
+++ b/apps/ex_ttrpg_dev/lib/rule_system/loader.ex
@@ -23,12 +23,23 @@ defmodule ExTTRPGDev.RuleSystem.Loader do
 
   ### Reserved concept type IDs
 
-  Two concept type IDs have structural meaning to the library:
+  Three concept type IDs have structural meaning to the library:
 
   - `"roll"` — concepts of this type define die rolling methods. Each must have
     `target_type`, `dice`, and `bonus_field` (see below).
   - `"character_progression"` — concepts of this type define character advancement
     tables. The library uses this type ID to locate progression decisions.
+  - `"rolling_method"` — concepts of this type define how `generated` nodes are
+    rolled at character generation. Keys:
+    - `"name"` *(string, optional)* — display name.
+    - `"dice"` *(string, required)* — dice expression rolled for the value (e.g.
+      `"4d6"`).
+    - `"drop"` *(string, optional)* — `"lowest"` drops the lowest die from the
+      roll. No other value is supported; anything else warns at load time and is
+      ignored.
+    - `"default"` *(boolean, optional)* — marks this method as the system-wide
+      default for `generated` nodes that do not declare a `"method"`. Exactly one
+      method should set it; multiple defaults warn at load time.
 
   ### Universal keys (any concept type)
 
@@ -131,6 +142,7 @@ defmodule ExTTRPGDev.RuleSystem.Loader do
          {:ok, inventory_rules} <- load_inventory_rules(path) do
       data = expand_metadata_contributions(data, rule_module)
       warn_unknown_metadata_keys(data.concept_metadata, rule_module, inventory_rules)
+      warn_rolling_method_issues(data)
       {:ok, data |> Map.put(:module, rule_module) |> Map.put(:inventory_rules, inventory_rules)}
     end
   end
@@ -337,13 +349,6 @@ defmodule ExTTRPGDev.RuleSystem.Loader do
     )
   end
 
-  defp warn_missing_node_fields(%{type: :generated, method: nil}, {type_id, concept_id, field}) do
-    Logger.warning(
-      "Node #{inspect(field)} on #{inspect(type_id)} concept #{inspect(concept_id)} " <>
-        "has type :generated but is missing required field \"method\"."
-    )
-  end
-
   defp warn_missing_node_fields(%{type: :mapping} = node, {type_id, concept_id, field}) do
     for {key, label} <- [{:input, "input"}, {:steps, "steps"}],
         is_nil(Map.get(node, key)) do
@@ -355,6 +360,52 @@ defmodule ExTTRPGDev.RuleSystem.Loader do
   end
 
   defp warn_missing_node_fields(_, _), do: :ok
+
+  # Runs after all concept files are loaded, because a generated node may
+  # legitimately rely on a default rolling method defined in a different file.
+  defp warn_rolling_method_issues(%{nodes: nodes, rolling_methods: methods}) do
+    default_ids = for {id, method} <- methods, method.default, do: id
+
+    if length(default_ids) > 1 do
+      Logger.warning(
+        "Multiple rolling methods declare default = true: " <>
+          "#{default_ids |> Enum.sort() |> Enum.join(", ")}. The default is ambiguous."
+      )
+    end
+
+    for {id, %{drop: drop}} <- methods, not is_nil(drop) and drop != "lowest" do
+      Logger.warning(
+        "Rolling method #{inspect(id)} has unsupported drop value #{inspect(drop)}; " <>
+          "only \"lowest\" is supported. The drop will be ignored."
+      )
+    end
+
+    for {node_key, %{type: :generated, method: method_id}} <- nodes do
+      warn_generated_method_issue(node_key, method_id, methods, default_ids)
+    end
+
+    :ok
+  end
+
+  defp warn_generated_method_issue({type_id, concept_id, field}, nil, _methods, []) do
+    Logger.warning(
+      "Node #{inspect(field)} on #{inspect(type_id)} concept #{inspect(concept_id)} " <>
+        "has type :generated with no \"method\", and no rolling method declares " <>
+        "default = true."
+    )
+  end
+
+  defp warn_generated_method_issue({type_id, concept_id, field}, method_id, methods, _defaults)
+       when not is_nil(method_id) do
+    unless Map.has_key?(methods, method_id) do
+      Logger.warning(
+        "Node #{inspect(field)} on #{inspect(type_id)} concept #{inspect(concept_id)} " <>
+          "references unknown rolling method #{inspect(method_id)}."
+      )
+    end
+  end
+
+  defp warn_generated_method_issue(_node_key, _method_id, _methods, _defaults), do: :ok
 
   defp parse_rolling_method(fields) do
     %{

--- a/apps/ex_ttrpg_dev/test/characters/character_test.exs
+++ b/apps/ex_ttrpg_dev/test/characters/character_test.exs
@@ -23,6 +23,40 @@ defmodule ExTTRPGDevTest.Characters.Character do
     assert character.inventory == []
   end
 
+  test "gen_character!/1 rolls methodless generated nodes via the default rolling method" do
+    system = RuleSystems.load_system!("dnd_5e_srd")
+    key = {"ability", "strength", "base_score"}
+    nodes = Map.update!(system.nodes, key, &%{&1 | method: nil})
+
+    character = Character.gen_character!(%{system | nodes: nodes})
+
+    score = character.generated_values[key]
+    assert is_integer(score) and score >= 3 and score <= 18
+  end
+
+  test "gen_character!/1 raises clearly for an unknown rolling method" do
+    system = RuleSystems.load_system!("dnd_5e_srd")
+    key = {"ability", "strength", "base_score"}
+    nodes = Map.update!(system.nodes, key, &%{&1 | method: "bogus"})
+
+    assert_raise RuntimeError, ~r/unknown rolling method "bogus"/, fn ->
+      Character.gen_character!(%{system | nodes: nodes})
+    end
+  end
+
+  test "gen_character!/1 raises clearly when no method is set and no default exists" do
+    system = RuleSystems.load_system!("dnd_5e_srd")
+    key = {"ability", "strength", "base_score"}
+    nodes = Map.update!(system.nodes, key, &%{&1 | method: nil})
+
+    no_defaults =
+      Map.new(system.rolling_methods, fn {id, method} -> {id, %{method | default: false}} end)
+
+    assert_raise RuntimeError, ~r/no rolling method declares\s+default = true/, fn ->
+      Character.gen_character!(%{system | nodes: nodes, rolling_methods: no_defaults})
+    end
+  end
+
   test "gen_character!/2 stores provided decisions" do
     system = RuleSystems.load_system!("dnd_5e_srd")
 

--- a/apps/ex_ttrpg_dev/test/rule_system/loader_test.exs
+++ b/apps/ex_ttrpg_dev/test/rule_system/loader_test.exs
@@ -726,7 +726,7 @@ defmodule ExTTRPGDev.RuleSystem.LoaderTest do
 
   # --- Required node field validation ---
 
-  test "generated node missing method produces a warning" do
+  test "generated node with no method and no default rolling method produces a warning" do
     log =
       capture_load_with_concept("ability", "strength", """
       [ability.strength]
@@ -735,7 +735,73 @@ defmodule ExTTRPGDev.RuleSystem.LoaderTest do
       """)
 
     assert log =~ ~s(Node "base_score" on "ability" concept "strength")
-    assert log =~ ~s(has type :generated but is missing required field "method")
+    assert log =~ ~s(no rolling method declares default = true)
+  end
+
+  test "generated node with no method is fine when a default rolling method exists" do
+    log =
+      with_tmp_system(["ability", "rolling_method"], fn dir ->
+        File.mkdir_p!(Path.join(dir, "concepts/ability"))
+
+        File.write!(Path.join(dir, "concepts/ability/strength.toml"), """
+        [rolling_method.standard_array]
+        name = "Standard"
+        dice = "4d6"
+        drop = "lowest"
+        default = true
+
+        [ability.strength]
+        name = "Strength"
+        base_score.type = "generated"
+        """)
+
+        capture_log(fn -> Loader.load!(dir) end)
+      end)
+
+    assert log == ""
+  end
+
+  test "generated node referencing an unknown rolling method produces a warning" do
+    log =
+      capture_load_with_concept("ability", "strength", """
+      [ability.strength]
+      name = "Strength"
+      base_score.type = "generated"
+      base_score.method = "nonexistent"
+      """)
+
+    assert log =~ ~s(references unknown rolling method "nonexistent")
+  end
+
+  test "unsupported drop value on a rolling method produces a warning" do
+    log =
+      capture_load_with_concept("rolling_method", "weird", """
+      [rolling_method.weird]
+      name = "Weird"
+      dice = "4d6"
+      drop = "highest"
+      """)
+
+    assert log =~ ~s(unsupported drop value "highest")
+    assert log =~ ~s(only "lowest" is supported)
+  end
+
+  test "multiple default rolling methods produce an ambiguity warning" do
+    log =
+      capture_load_with_concept("rolling_method", "methods", """
+      [rolling_method.first]
+      name = "First"
+      dice = "4d6"
+      default = true
+
+      [rolling_method.second]
+      name = "Second"
+      dice = "3d6"
+      default = true
+      """)
+
+    assert log =~ "Multiple rolling methods declare default = true"
+    assert log =~ "first, second"
   end
 
   test "mapping node missing input and steps produces warnings" do


### PR DESCRIPTION
Closes #123

## Why

`roll_generated_value` fell back to `Map.get(rolling_methods, method_id || "standard")` — domain vocabulary from dnd_5e_srd's TOML hardcoded in library source, violating the library/config boundary. A second system without a method named `"standard"` crashed with `nil.dice` for any methodless generated node; an unknown explicit method id crashed the same way.

## What

The config mechanism already existed: rolling methods carry a `default` flag (dnd's `standard` sets `default = true`), parsed by the loader and then ignored by the library. Now:

- Methodless generated nodes resolve to the method flagged `default = true`.
- Unknown method id → clear raise naming the id; methodless node with no default → clear raise explaining the fix. No more `nil.dice`.

Load-time validation added (warn-and-degrade, matching loader posture):
- The missing-method warning moved to a **post-load pass** — a methodless node is now legitimate when a default exists (possibly in another concept file), so the check needs the complete `rolling_methods` map. It fires only when no default is declared.
- Unknown `method` reference on a generated node warns.
- `drop` values other than `"lowest"` warn and are ignored (previously silent).
- Multiple `default = true` methods warn as ambiguous.

The `"rolling_method"` reserved concept type and its keys (`name`/`dice`/`drop`/`default`) are now documented in the structural-vocabulary moduledoc; it was special-cased in code but missing from the reserved-types list. (Vocabulary constant centralization stays #125.)

## Verification

- `grep '"standard"' apps/ex_ttrpg_dev/lib/` — zero hits.
- 5 new/updated loader tests (no-default warning, default-satisfies-methodless, unknown method, unsupported drop, ambiguous defaults) + 3 new character tests (default-method roll works, unknown-method raise, no-default raise).
- dnd_5e_srd still loads with zero warnings and generation behaves identically (existing tests unchanged).
- Full suite (312 + 55), credo, dialyzer, CodeScene delta all pass.


<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Introduced a 'rolling_method' concept type to define character generation dice rolling rules, including support for defaults and drop-lowest mechanics.</li>
<li>Updated character generation to automatically resolve rolling methods, defaulting to the system-wide default if no method is specified.</li>
<li>Added validation and warning logic in the rule loader to detect ambiguous defaults, unsupported drop values, and missing rolling methods.</li>
<li>Improved error handling for unknown rolling methods during character generation.</li>
</ul></div>