### PR TITLE
refactor: expose Character.slugify/1 and Expression.parse_ref/1, delete copies

### DIFF
--- a/apps/ex_ttrpg_dev/lib/characters/character.ex
+++ b/apps/ex_ttrpg_dev/lib/characters/character.ex
@@ -252,7 +252,23 @@ defmodule ExTTRPGDev.Characters.Character do
       raise "unknown rolling method #{inspect(method_id)}"
   end
 
-  defp slugify(name) do
+  @doc """
+  Converts a character name into its canonical slug.
+
+  This is the single definition of the slug rules — any caller that derives
+  a slug from a name (e.g. frontends creating characters) must use it, or
+  characters saved under one slug become unfindable under another.
+
+  ## Examples
+
+      iex> ExTTRPGDev.Characters.Character.slugify("Mr. Whiskers")
+      "mr_whiskers"
+
+      iex> ExTTRPGDev.Characters.Character.slugify("D'Artagnan the Bold")
+      "dartagnan_the_bold"
+
+  """
+  def slugify(name) do
     name
     |> String.downcase()
     |> String.replace(~r/[!#$%&()*+,.:;<=>?@\^_`'{|}~-]/, "")

--- a/apps/ex_ttrpg_dev/lib/rule_system/expression.ex
+++ b/apps/ex_ttrpg_dev/lib/rule_system/expression.ex
@@ -29,6 +29,8 @@ defmodule ExTTRPGDev.RuleSystem.Expression do
   """
 
   @ref_pattern ~r/(\w+)\('([^']+)'\)\.(\w+)/
+  @single_ref_pattern Regex.compile!("^" <> Regex.source(@ref_pattern) <> "$")
+  @leading_ref_pattern Regex.compile!("^" <> Regex.source(@ref_pattern))
 
   @doc """
   Extracts all concept references from a formula string.
@@ -55,6 +57,34 @@ defmodule ExTTRPGDev.RuleSystem.Expression do
       {type_id, concept_id, field_name}
     end)
     |> Enum.uniq()
+  end
+
+  @doc """
+  Parses a string consisting of exactly one node reference.
+
+  Unlike `extract_refs/1`, the whole string must be a single reference —
+  use this for values that are node keys (e.g. effect targets), not
+  formulas.
+
+  Returns `{:ok, {type_id, concept_id, field_name}}` or `:error`.
+
+  ## Examples
+
+      iex> ExTTRPGDev.RuleSystem.Expression.parse_ref("ability('strength').modifier")
+      {:ok, {"ability", "strength", "modifier"}}
+
+      iex> ExTTRPGDev.RuleSystem.Expression.parse_ref("ability(strength).modifier")
+      :error
+
+      iex> ExTTRPGDev.RuleSystem.Expression.parse_ref("ability('strength').modifier + 1")
+      :error
+
+  """
+  def parse_ref(string) when is_binary(string) do
+    case Regex.run(@single_ref_pattern, string, capture: :all_but_first) do
+      [type_id, concept_id, field_name] -> {:ok, {type_id, concept_id, field_name}}
+      nil -> :error
+    end
   end
 
   @doc """
@@ -126,7 +156,7 @@ defmodule ExTTRPGDev.RuleSystem.Expression do
       ws = leading_match(~r/^\s+/, input) ->
         tokenize(chop(input, ws), acc)
 
-      ref = Regex.run(~r/^(\w+)\('([^']+)'\)\.(\w+)/, input) ->
+      ref = Regex.run(@leading_ref_pattern, input) ->
         [full, type_id, concept_id, field_name] = ref
         tokenize(chop(input, full), [{:ref, {type_id, concept_id, field_name}} | acc])
 

--- a/apps/ex_ttrpg_dev/lib/rule_system/loader.ex
+++ b/apps/ex_ttrpg_dev/lib/rule_system/loader.ex
@@ -120,7 +120,7 @@ defmodule ExTTRPGDev.RuleSystem.Loader do
 
   require Logger
 
-  alias ExTTRPGDev.RuleSystem.{InventoryRules, RuleModule}
+  alias ExTTRPGDev.RuleSystem.{Expression, InventoryRules, RuleModule}
 
   @module_file "module.toml"
 
@@ -531,16 +531,16 @@ defmodule ExTTRPGDev.RuleSystem.Loader do
   end
 
   defp parse_effect(source, %{"target" => target, "value" => value} = entry) do
-    case Regex.run(~r/(\w+)\('([^']+)'\)\.(\w+)/, target) do
-      [_, type_id, concept_id, field_name] ->
+    case Expression.parse_ref(target) do
+      {:ok, ref} ->
         %{
           source: source,
-          target: {type_id, concept_id, field_name},
+          target: ref,
           value: value,
           when: Map.get(entry, "when")
         }
 
-      _ ->
+      :error ->
         {source_type, source_id} = source
 
         Logger.warning(

--- a/apps/ex_ttrpg_dev/test/rule_system/loader_test.exs
+++ b/apps/ex_ttrpg_dev/test/rule_system/loader_test.exs
@@ -869,30 +869,27 @@ defmodule ExTTRPGDev.RuleSystem.LoaderTest do
     end)
   end
 
-  test "unparseable contributes target warns and skips the effect" do
-    {log, data} =
-      load_and_capture("ability", "strength", """
-      [ability.strength]
-      name = "Strength"
-      contributes = [{target = "ability(dexterity).total_score", value = 2}]
-      """)
+  test "malformed contributes entries warn and are skipped" do
+    malformed_cases = [
+      # unparseable target (missing quotes around the concept id)
+      {~s|[{target = "ability(dexterity).total_score", value = 2}]|, "unparseable target"},
+      # trailing content after the ref — a target must be exactly one ref
+      {~s|[{target = "ability('dexterity').total_score + 1", value = 2}]|, "unparseable target"},
+      # entry missing the required "value" key
+      {~s|[{target = "ability('dexterity').total_score"}]|, ~s{missing required key(s)}}
+    ]
 
-    assert data.effects == []
-    assert log =~ "unparseable target"
-    assert log =~ ~s{"ability(dexterity).total_score"}
-  end
+    for {contributes, expected_warning} <- malformed_cases do
+      {log, data} =
+        load_and_capture("ability", "strength", """
+        [ability.strength]
+        name = "Strength"
+        contributes = #{contributes}
+        """)
 
-  test "contributes entry missing target or value warns and skips the effect" do
-    {log, data} =
-      load_and_capture("ability", "strength", """
-      [ability.strength]
-      name = "Strength"
-      contributes = [{target = "ability('dexterity').total_score"}]
-      """)
-
-    assert data.effects == []
-    assert log =~ ~s{missing required key(s) "target" and/or "value"}
-    assert log =~ "strength"
+      assert data.effects == [], "expected no effects for contributes = #{contributes}"
+      assert log =~ expected_warning
+    end
   end
 
   test "unrecognized node type warns and skips the node instead of crashing" do

--- a/apps/ttrpg_dev_cli/lib/cli/server.ex
+++ b/apps/ttrpg_dev_cli/lib/cli/server.ex
@@ -47,7 +47,7 @@ defmodule ExTTRPGDev.CLI.Server do
   alias ExTTRPGDev.Characters
   alias ExTTRPGDev.Characters.{Character, InventoryItem}
   alias ExTTRPGDev.CLI.Serializer
-  alias ExTTRPGDev.RuleSystem.{Evaluator, InventoryRules}
+  alias ExTTRPGDev.RuleSystem.{Evaluator, Expression, InventoryRules}
   alias ExTTRPGDev.RuleSystems
   alias ExTTRPGDev.RuleSystems.LoadedSystem
 
@@ -186,7 +186,7 @@ defmodule ExTTRPGDev.CLI.Server do
       system = RuleSystems.load_system!(slug)
       character = Character.gen_character!(system, [])
 
-      slug = slugify_name(name)
+      slug = Character.slugify(name)
       character = %{character | name: name, metadata: %{character.metadata | slug: slug}}
       temp_id = Integer.to_string(state.next_id)
       pending = Map.put(state.pending, temp_id, character)
@@ -811,12 +811,10 @@ defmodule ExTTRPGDev.CLI.Server do
     end
   end
 
-  @effect_target_regex ~r/^(\w+)\('([^']+)'\)\.(\w+)$/
-
   defp parse_effect_target!(target) do
-    case Regex.run(@effect_target_regex, target, capture: :all_but_first) do
-      [type_id, concept_id, field] -> {type_id, concept_id, field}
-      _ -> raise("invalid effect target: #{inspect(target)}")
+    case Expression.parse_ref(target) do
+      {:ok, ref} -> ref
+      :error -> raise("invalid effect target: #{inspect(target)}")
     end
   end
 
@@ -869,13 +867,6 @@ defmodule ExTTRPGDev.CLI.Server do
 
   defp fetch_pending!(state, temp_id) do
     Map.get(state.pending, temp_id) || raise("no pending character: #{inspect(temp_id)}")
-  end
-
-  defp slugify_name(name) do
-    name
-    |> String.downcase()
-    |> String.replace(~r/[!#$%&()*+,.:;<=>?@\^_`'{|}~-]/, "")
-    |> String.replace(" ", "_")
   end
 
   defp parse_display_mode(msg) do


### PR DESCRIPTION
Closes #124

## What

- **`Character.slugify/1` is now public** with doctests, documented as the single definition of the slug rules. The server's byte-for-byte `slugify_name` copy is deleted — previously, if the library's slug rules changed, characters created via `build_start` would become unfindable.
- **`Expression.parse_ref/1`** parses a whole-string single node ref, returning `{:ok, {type, id, field}} | :error`. `Loader.parse_effect` and the server's `parse_effect_target!` both use it; the server's `@effect_target_regex` is deleted. The anchored/leading variants Expression needs internally are derived from `@ref_pattern` via `Regex.source` at compile time — the pattern literal now exists exactly once in the codebase.

## Behavior note

`parse_ref` is anchored, so `Loader.parse_effect` no longer prefix-matches targets with trailing content: `target = "ability('dexterity').total_score + 1"` previously matched the leading ref and silently discarded the `+ 1`; it now warns and skips the effect, consistent with #149's unparseable-target handling. Covered in the (now table-driven) malformed-contributes loader test.

## Verification

- New doctests for `parse_ref` (valid ref, missing quotes, trailing content) and `slugify`.
- dnd_5e_srd still loads with zero warnings (all its targets are exact refs).
- Full suite (313 + 55), credo, dialyzer, CodeScene delta all pass.


<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Centralized character name slugification logic into `ExTTRPGDev.Characters.Character.slugify/1`.</li>
<li>Added `ExTTRPGDev.RuleSystem.Expression.parse_ref/1` to strictly validate and parse node references.</li>
<li>Refactored `RuleSystem.Loader` and `CLI.Server` to use the new `parse_ref/1` function for consistent target parsing.</li>
<li>Updated `LoaderTest` to include more comprehensive test cases for malformed contributes entries.</li>
</ul></div>