### PR TITLE
ci: stop Coveralls upload failures from blocking the Rust job

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -72,12 +72,18 @@ jobs:
     - name: Test and coverage
       working-directory: cli
       run: cargo llvm-cov --lcov --output-path lcov.info --bin ttrpg-dev
+    # parallel mode is deliberately NOT used: it requires a closing
+    # parallel-finished webhook (which this workflow never sent, leaving
+    # Coveralls builds dangling open), and the Elixir job reports through
+    # excoveralls' own integration, so this is the only upload here.
+    # fail-on-error keeps a Coveralls outage from blocking CI — coverage
+    # is reporting, not a merge gate.
     - name: Upload coverage to Coveralls
       uses: coverallsapp/github-action@v2
       with:
         file: cli/lcov.info
         flag-name: rust
-        parallel: true
+        fail-on-error: false
     - name: Machete
       uses: bnjbvr/cargo-machete@main
       with:


### PR DESCRIPTION
## Why

Every push-to-main CI run since #145 — and now PR #151's runs — failed at **Upload coverage to Coveralls** with `⚠️ Internal server error. Please contact Coveralls team.`, while build, clippy, and tests all pass. A re-run reproduced the 500, so it's persistent, not a one-off blip.

## What

Two changes to the Rust job's upload step:

1. **Drop `parallel: true`** — parallel mode requires a closing `parallel-finished` webhook that this workflow never sent, so every build has been left dangling open on Coveralls' side (the likely trigger for the persistent 500s). It's also unnecessary: the Elixir job reports via excoveralls' own GitHub integration, making this the only coverallsapp upload in the workflow.
2. **Add `fail-on-error: false`** — coverage upload is reporting, not a merge gate; a third-party outage should never block CI. Coverage regressions remain visible on coveralls.io and in PR comments.

## Verification

Once merged, re-running PR #151's checks will pick up the fixed workflow via the PR merge ref.
