### PR TITLE
refactor: centralize structural vocabulary in a Vocabulary module

### DIFF
--- a/apps/ex_ttrpg_dev/lib/characters.ex
+++ b/apps/ex_ttrpg_dev/lib/characters.ex
@@ -10,7 +10,13 @@ defmodule ExTTRPGDev.Characters do
   alias ExTTRPGDev.RuleSystem.Evaluator
   alias ExTTRPGDev.RuleSystem.Expression
   alias ExTTRPGDev.RuleSystem.InventoryRules
+  alias ExTTRPGDev.RuleSystem.Vocabulary
   alias ExTTRPGDev.RuleSystems.LoadedSystem
+
+  # Bound to attributes for use in pattern-match positions; the names are
+  # owned by ExTTRPGDev.RuleSystem.Vocabulary.
+  @progression_type Vocabulary.progression_type()
+  @roll_type Vocabulary.roll_type()
 
   @doc """
   Get the file path for a character
@@ -435,7 +441,7 @@ defmodule ExTTRPGDev.Characters do
     roll_def =
       system.concept_metadata
       |> Enum.find(fn {{type, _id}, meta} ->
-        type == "roll" and meta["target_type"] == type_id
+        type == @roll_type and meta["target_type"] == type_id
       end)
 
     unless roll_def do
@@ -485,7 +491,7 @@ defmodule ExTTRPGDev.Characters do
 
     progression_choices =
       system.concept_metadata
-      |> Enum.filter(fn {{type, _id}, _} -> type == "character_progression" end)
+      |> Enum.filter(fn {{type, _id}, _} -> type == @progression_type end)
       |> Enum.flat_map(fn {{_type, id}, meta} ->
         roll = resolve_roll_reference(meta["roll_reference"], character, system.concept_metadata)
         meta_with_roll = Map.put(meta, "roll", roll)
@@ -557,14 +563,7 @@ defmodule ExTTRPGDev.Characters do
   end
 
   defp apply_auto_selection(character, %{id: prog_id, options: options}) do
-    n = count_progression_decisions(character.decisions, prog_id) + 1
-
-    decision = %{
-      scope: {"character_progression", prog_id},
-      choice: "choice_#{n}",
-      selection: Enum.random(options)
-    }
-
+    decision = next_progression_decision(character.decisions, prog_id, Enum.random(options))
     %{character | decisions: character.decisions ++ [decision]}
   end
 
@@ -579,16 +578,10 @@ defmodule ExTTRPGDev.Characters do
   end
 
   defp apply_auto_value(character, %{id: prog_id, effect_target: target_str, roll: roll}) do
-    n = count_progression_decisions(character.decisions, prog_id) + 1
     [node_key | _] = Expression.extract_refs(target_str)
     value = Dice.roll("1#{roll}") |> Enum.sum()
 
-    decision = %{
-      scope: {"character_progression", prog_id},
-      choice: "choice_#{n}",
-      selection: "rolled"
-    }
-
+    decision = next_progression_decision(character.decisions, prog_id, "rolled")
     effect = %{target: node_key, value: value}
 
     %{
@@ -675,16 +668,9 @@ defmodule ExTTRPGDev.Characters do
 
   defp track_selection_resolution(system, entry, character) do
     selection = Enum.random(entry.options)
-    n = count_progression_decisions(character.decisions, entry.id) + 1
-
-    decision = %{
-      scope: {"character_progression", entry.id},
-      choice: "choice_#{n}",
-      selection: selection
-    }
-
+    decision = next_progression_decision(character.decisions, entry.id, selection)
     updated = %{character | decisions: character.decisions ++ [decision]}
-    meta = system.concept_metadata[{"character_progression", entry.id}]
+    meta = system.concept_metadata[{@progression_type, entry.id}]
 
     resolution = %{
       name: entry.name,
@@ -700,15 +686,9 @@ defmodule ExTTRPGDev.Characters do
 
   defp track_value_resolution(entry, character) do
     {method, value} = random_value_method(entry.roll)
-    n = count_progression_decisions(character.decisions, entry.id) + 1
     [node_key | _] = Expression.extract_refs(entry.effect_target)
 
-    decision = %{
-      scope: {"character_progression", entry.id},
-      choice: "choice_#{n}",
-      selection: method
-    }
-
+    decision = next_progression_decision(character.decisions, entry.id, method)
     effect = %{target: node_key, value: value}
 
     updated = %{
@@ -768,7 +748,7 @@ defmodule ExTTRPGDev.Characters do
 
       selection_progressions =
         Enum.filter(system.concept_metadata, fn {{type, _id}, meta} ->
-          type == "character_progression" and
+          type == @progression_type and
             Map.has_key?(meta, "type") and
             get_in(meta, ["filter", "max_level_node"]) != nil
         end)
@@ -820,7 +800,7 @@ defmodule ExTTRPGDev.Characters do
     progression_type_map =
       concept_metadata
       |> Enum.filter(fn {{type, _id}, meta} ->
-        type == "character_progression" and Map.has_key?(meta, "type")
+        type == @progression_type and Map.has_key?(meta, "type")
       end)
       |> Map.new(fn {{_type, id}, meta} -> {id, meta["type"]} end)
 
@@ -828,12 +808,12 @@ defmodule ExTTRPGDev.Characters do
       decisions
       |> Enum.filter(fn d ->
         case d.scope do
-          {"character_progression", prog_id} -> Map.has_key?(progression_type_map, prog_id)
+          {@progression_type, prog_id} -> Map.has_key?(progression_type_map, prog_id)
           _ -> false
         end
       end)
       |> Enum.reduce(%{}, fn d, acc ->
-        {"character_progression", prog_id} = d.scope
+        {@progression_type, prog_id} = d.scope
         concept_type = Map.fetch!(progression_type_map, prog_id)
         Map.update(acc, {concept_type, d.selection}, 1, &(&1 + 1))
       end)
@@ -898,7 +878,7 @@ defmodule ExTTRPGDev.Characters do
          true <- pending_count > 0 do
       already_selected =
         decisions
-        |> Enum.filter(fn d -> d.scope == {"character_progression", id} end)
+        |> Enum.filter(fn d -> d.scope == {@progression_type, id} end)
         |> MapSet.new(& &1.selection)
 
       {max_level_cap, earned_at_level} = find_next_slot(pending_choice_slots, id)
@@ -1055,9 +1035,22 @@ defmodule ExTTRPGDev.Characters do
 
   defp progression_choices(_id, _meta, _decisions, _resolved), do: []
 
+  # The single constructor for progression decisions: computes the next
+  # 1-based choice number from the decisions already made and builds the
+  # canonical decision map.
+  defp next_progression_decision(decisions, progression_id, selection) do
+    n = count_progression_decisions(decisions, progression_id) + 1
+
+    %{
+      scope: Vocabulary.progression_scope(progression_id),
+      choice: Vocabulary.progression_choice_id(n),
+      selection: selection
+    }
+  end
+
   defp count_progression_decisions(decisions, progression_id) do
     Enum.count(decisions, fn
-      %{scope: {"character_progression", ^progression_id}} -> true
+      %{scope: {@progression_type, ^progression_id}} -> true
       _ -> false
     end)
   end

--- a/apps/ex_ttrpg_dev/lib/rule_system/loader.ex
+++ b/apps/ex_ttrpg_dev/lib/rule_system/loader.ex
@@ -120,20 +120,18 @@ defmodule ExTTRPGDev.RuleSystem.Loader do
 
   require Logger
 
-  alias ExTTRPGDev.RuleSystem.{Expression, InventoryRules, RuleModule}
+  alias ExTTRPGDev.RuleSystem.{Expression, InventoryRules, RuleModule, Vocabulary}
 
   @module_file "module.toml"
-
-  # All concept metadata keys read by the library at runtime. Keys not in this
-  # set and not otherwise declared will trigger a Logger.warning at load time.
-  # See the "Structural Vocabulary" section of this module's docs for semantics.
-  @structural_metadata_keys MapSet.new(~w(
-    name type required_count available_when effect_target roll_reference roll
-    filter choices level requires starting_equipment target_type dice bonus_field
-    contributes hidden
-  ))
   @character_building_file "character_building.toml"
   @inventory_rules_file "inventory_rules.toml"
+
+  # Bound to attributes at compile time; the names are owned by
+  # ExTTRPGDev.RuleSystem.Vocabulary. The MapSet is bound here rather than
+  # fetched per-call because dialyzer loses MapSet's opaqueness across the
+  # module boundary and rejects the cross-module value in MapSet.union/2.
+  @rolling_method_type Vocabulary.rolling_method_type()
+  @structural_metadata_keys MapSet.new(Vocabulary.structural_metadata_keys())
 
   @doc "Loads a rule system directory, returning `{:ok, data}` or `{:error, reason}`."
   def load(path) do
@@ -256,7 +254,7 @@ defmodule ExTTRPGDev.RuleSystem.Loader do
     end)
   end
 
-  defp process_type("rolling_method", concepts, acc) do
+  defp process_type(@rolling_method_type, concepts, acc) do
     rolling_methods =
       Enum.reduce(concepts, acc.rolling_methods, fn {id, fields}, rm ->
         method = parse_rolling_method(fields)

--- a/apps/ex_ttrpg_dev/lib/rule_system/vocabulary.ex
+++ b/apps/ex_ttrpg_dev/lib/rule_system/vocabulary.ex
@@ -1,0 +1,64 @@
+defmodule ExTTRPGDev.RuleSystem.Vocabulary do
+  @moduledoc """
+  Single source of truth for the library's structural vocabulary — the
+  reserved concept type IDs and metadata keys the library itself defines to
+  interpret rule-system config.
+
+  The *semantics* of every name are documented in the "Structural Vocabulary"
+  section of `ExTTRPGDev.RuleSystem.Loader`. This module exists so each name
+  is spelled exactly once in code: renaming or extending the vocabulary must
+  never require a grep-sweep across the library.
+
+  Consumers that need a name in a pattern-match position bind it to a module
+  attribute at compile time (e.g. `@progression_type Vocabulary.progression_type()`).
+  """
+
+  @progression_type "character_progression"
+  @roll_type "roll"
+  @rolling_method_type "rolling_method"
+
+  # All concept metadata keys read by the library at runtime. Keys not in
+  # this set and not otherwise declared trigger a Logger.warning at load
+  # time (see Loader.warn_unknown_metadata_keys/3). Kept as a plain list;
+  # the MapSet is built at call time because embedding a compile-time
+  # MapSet literal violates its opaque type under dialyzer.
+  @structural_metadata_keys ~w(
+    name type required_count available_when effect_target roll_reference roll
+    filter choices level requires starting_equipment target_type dice bonus_field
+    contributes hidden
+  )
+
+  @doc "Reserved type ID for character advancement (progression) concepts."
+  def progression_type, do: @progression_type
+
+  @doc "Reserved type ID for die-roll definition concepts."
+  def roll_type, do: @roll_type
+
+  @doc "Reserved type ID for rolling-method concepts."
+  def rolling_method_type, do: @rolling_method_type
+
+  @doc "The set of concept metadata keys the library reads at runtime."
+  def structural_metadata_keys, do: MapSet.new(@structural_metadata_keys)
+
+  @doc """
+  The decision scope tuple for a choice made under a progression.
+
+  ## Examples
+
+      iex> ExTTRPGDev.RuleSystem.Vocabulary.progression_scope("asi_or_feat")
+      {"character_progression", "asi_or_feat"}
+
+  """
+  def progression_scope(progression_id), do: {@progression_type, progression_id}
+
+  @doc """
+  The canonical choice ID for the nth (1-based) choice of a progression.
+
+  ## Examples
+
+      iex> ExTTRPGDev.RuleSystem.Vocabulary.progression_choice_id(2)
+      "choice_2"
+
+  """
+  def progression_choice_id(n) when is_integer(n) and n >= 1, do: "choice_#{n}"
+end


### PR DESCRIPTION
Closes #125

## What

`ExTTRPGDev.RuleSystem.Vocabulary` now owns every structural name the library defines:

- Reserved concept type IDs: `progression_type/0`, `roll_type/0`, `rolling_method_type/0`
- The structural metadata key set (moved from `Loader`'s module attribute)
- The progression decision shape: `progression_scope/1` and `progression_choice_id/1` (with doctests)

`"character_progression"` appeared at 12 sites in `characters.ex` and `"choice_#{n}"` at 4 — all now flow through Vocabulary. The four identical decision constructions (each also recomputing the next choice number) collapse into one `next_progression_decision/3` constructor. Semantics remain documented in Loader's "Structural Vocabulary" section, which Vocabulary's moduledoc references.

## Notable decisions

- **Pattern positions**: consumers bind names to module attributes at compile time (`@progression_type Vocabulary.progression_type()`) since function calls can't appear in patterns. The literal still exists only in Vocabulary.
- **Dialyzer opaqueness**: Loader binds the key set to an attribute instead of calling Vocabulary inline — dialyzer loses `MapSet`'s opaqueness across module boundaries and flags the cross-module value in `MapSet.union/2`. Documented in a comment.
- **CLI app untouched**: the server/serializer's own `"character_progression"` references stay — the app is allowed to be system-aware, and migrating it can ride along with the handler split (#132).
- A proper `Decision` struct remains #133's territory.

## Verification

No behavior change: full suite passes unchanged (311 + 55 tests, +2 new Vocabulary doctests), credo and dialyzer clean, grep confirms zero structural literals left in library logic outside `vocabulary.ex`.


<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Introduced a new `Vocabulary` module to centralize and manage reserved concept type IDs and metadata keys.</li>
<li>Refactored `Characters` and `Loader` modules to use the `Vocabulary` module instead of hardcoded strings for concept types and metadata keys.</li>
<li>Standardized the creation of progression decisions by introducing `next_progression_decision/3` in the `Characters` module.</li>
<li>Improved maintainability by ensuring structural vocabulary names are defined in a single location.</li>
</ul></div>