### PR TITLE
perf: eliminate duplicate full-DAG evaluation per server mutation

### DIFF
--- a/apps/ex_ttrpg_dev/lib/characters.ex
+++ b/apps/ex_ttrpg_dev/lib/characters.ex
@@ -240,8 +240,7 @@ defmodule ExTTRPGDev.Characters do
   # while preparation_state degrades tolerantly.
   defp prep_context(system, character, {class_type, class_id} = class_key, opts) do
     %{type_id: type_id, prep: prep} = opts
-    effects = active_effects(system, character)
-    resolved = Evaluator.evaluate!(system, character.generated_values, effects)
+    {_effects, resolved} = resolved_state(system, character)
     max_level = trunc(resolved[prep.max_level_node] || 0)
     pool_name = get_in(system.concept_metadata, [class_key, prep.pool_field])
     pool_config = fetch_pool_config(prep, pool_name)
@@ -439,6 +438,19 @@ defmodule ExTTRPGDev.Characters do
   end
 
   @doc """
+  Computes the character's active effects and evaluates the full system DAG against them.
+
+  Returns `{effects, resolved}` where `effects` is the output of `active_effects/2` and
+  `resolved` is the node-value map from `Evaluator.evaluate!/3`. This is the canonical
+  way to obtain a character's resolved state; callers that need only one element can
+  discard the other.
+  """
+  def resolved_state(%LoadedSystem{} = system, %Character{} = character) do
+    effects = active_effects(system, character)
+    {effects, Evaluator.evaluate!(system, character.generated_values, effects)}
+  end
+
+  @doc """
   Rolls for a concept using the roll definition attached to its type in the system config.
 
   Looks up a roll definition (from the system's `roll` concept type) whose `target_type`
@@ -464,8 +476,7 @@ defmodule ExTTRPGDev.Characters do
 
     {_key, %{"dice" => dice_str, "bonus_field" => bonus_field}} = roll_def
 
-    effects = active_effects(system, character)
-    resolved = Evaluator.evaluate!(system, character.generated_values, effects)
+    {_effects, resolved} = resolved_state(system, character)
 
     bonus_key = {type_id, concept_id, bonus_field}
 
@@ -584,8 +595,7 @@ defmodule ExTTRPGDev.Characters do
          value_method,
          acc
        ) do
-    all_effects = active_effects(system, character)
-    resolved = Evaluator.evaluate!(system, character.generated_values, all_effects)
+    {_effects, resolved} = resolved_state(system, character)
     choices = pending_choices(system, character, resolved)
 
     case Enum.find(choices, resolvable?) do
@@ -719,8 +729,7 @@ defmodule ExTTRPGDev.Characters do
   def compute_pending_choice_slots(%LoadedSystem{} = system, %Character{} = character) do
     with level_node when not is_nil(level_node) <- system.module.level_node,
          [level_node_key | _] <- Expression.extract_refs(level_node) do
-      all_effects = active_effects(system, character)
-      resolved = Evaluator.evaluate!(system, character.generated_values, all_effects)
+      {all_effects, resolved} = resolved_state(system, character)
       current_level = trunc(resolved[level_node_key] || 1)
 
       thresholds = level_xp_thresholds(system)

--- a/apps/ttrpg_dev_cli/lib/cli/serializer.ex
+++ b/apps/ttrpg_dev_cli/lib/cli/serializer.ex
@@ -8,7 +8,7 @@ defmodule ExTTRPGDev.CLI.Serializer do
   alias ExTTRPGDev.Characters
   alias ExTTRPGDev.Characters.{Character, InventoryItem}
   alias ExTTRPGDev.CLI.ConceptDisplay
-  alias ExTTRPGDev.RuleSystem.{Evaluator, InventoryRules}
+  alias ExTTRPGDev.RuleSystem.InventoryRules
   alias ExTTRPGDev.RuleSystems.LoadedSystem
 
   def serialize_system(%LoadedSystem{module: mod}) do
@@ -39,11 +39,11 @@ defmodule ExTTRPGDev.CLI.Serializer do
         %LoadedSystem{} = system,
         %Character{} = character,
         slug,
-        display_mode
+        display_mode,
+        resolved \\ nil
       ) do
     active = Characters.active_concepts(character.decisions, system.concept_metadata)
-    effects = Characters.active_effects(system, character)
-    resolved = Evaluator.evaluate!(system, character.generated_values, effects)
+    resolved = resolved || elem(Characters.resolved_state(system, character), 1)
     resolved_by_concept = Enum.group_by(resolved, fn {{type, id, _field}, _} -> {type, id} end)
     inventory_ids = MapSet.new(character.inventory, &{&1.concept_type, &1.concept_id})
 

--- a/apps/ttrpg_dev_cli/lib/cli/server.ex
+++ b/apps/ttrpg_dev_cli/lib/cli/server.ex
@@ -47,7 +47,7 @@ defmodule ExTTRPGDev.CLI.Server do
   alias ExTTRPGDev.Characters
   alias ExTTRPGDev.Characters.{Character, InventoryItem}
   alias ExTTRPGDev.CLI.Serializer
-  alias ExTTRPGDev.RuleSystem.{Evaluator, Expression, InventoryRules}
+  alias ExTTRPGDev.RuleSystem.{Expression, InventoryRules}
   alias ExTTRPGDev.RuleSystems
   alias ExTTRPGDev.RuleSystems.LoadedSystem
 
@@ -269,10 +269,10 @@ defmodule ExTTRPGDev.CLI.Server do
       updated = %{char | inventory: inv, pending_choice_slots: slots}
       Characters.save_character!(updated)
       new_state = %{state | pending: Map.delete(state.pending, temp_id)}
-      resolved = resolve_character(sys, updated)
+      {_effects, resolved} = Characters.resolved_state(sys, updated)
       choices = Characters.pending_choices(sys, updated, resolved)
       mode = parse_display_mode(msg)
-      ser = Serializer.serialize_character(sys, updated, updated.metadata.slug, mode)
+      ser = Serializer.serialize_character(sys, updated, updated.metadata.slug, mode, resolved)
       data = Map.put(ser, :pending_choices, Serializer.serialize_choices_list(choices, sys, mode))
 
       {ok(data), new_state}
@@ -343,11 +343,11 @@ defmodule ExTTRPGDev.CLI.Server do
       updated = %{updated | pending_choice_slots: new_slots}
       Characters.save_character!(updated, true)
 
-      resolved = resolve_character(system, updated)
+      {_effects, resolved} = Characters.resolved_state(system, updated)
       choices = Characters.pending_choices(system, updated, resolved)
 
       data =
-        Serializer.serialize_character(system, updated, slug, parse_display_mode(msg))
+        Serializer.serialize_character(system, updated, slug, parse_display_mode(msg), resolved)
         |> Map.put(
           :pending_choices,
           Serializer.serialize_choices_list(choices, system, parse_display_mode(msg))
@@ -377,11 +377,11 @@ defmodule ExTTRPGDev.CLI.Server do
       updated = %{updated | pending_choice_slots: new_slots}
       Characters.save_character!(updated, true)
 
-      resolved = resolve_character(system, updated)
+      {_effects, resolved} = Characters.resolved_state(system, updated)
       choices = Characters.pending_choices(system, updated, resolved)
 
       data =
-        Serializer.serialize_character(system, updated, slug, parse_display_mode(msg))
+        Serializer.serialize_character(system, updated, slug, parse_display_mode(msg), resolved)
         |> Map.put(
           :pending_choices,
           Serializer.serialize_choices_list(choices, system, parse_display_mode(msg))
@@ -399,7 +399,7 @@ defmodule ExTTRPGDev.CLI.Server do
       character = Characters.load_character!(slug)
       system = RuleSystems.load_system!(character.metadata.rule_system)
 
-      resolved = resolve_character(system, character)
+      {_effects, resolved} = Characters.resolved_state(system, character)
       choices = Characters.pending_choices(system, character, resolved)
 
       {ok(%{
@@ -442,7 +442,7 @@ defmodule ExTTRPGDev.CLI.Server do
 
       updated =
         if Map.has_key?(meta, "type") do
-          resolved = resolve_character(system, character)
+          {_effects, resolved} = Characters.resolved_state(system, character)
           active = Characters.active_concepts(character.decisions, system.concept_metadata)
 
           already_selected =
@@ -479,11 +479,11 @@ defmodule ExTTRPGDev.CLI.Server do
 
       Characters.save_character!(updated, true)
 
-      resolved = resolve_character(system, updated)
+      {_effects, resolved} = Characters.resolved_state(system, updated)
       choices = Characters.pending_choices(system, updated, resolved)
 
       data =
-        Serializer.serialize_character(system, updated, slug, parse_display_mode(msg))
+        Serializer.serialize_character(system, updated, slug, parse_display_mode(msg), resolved)
         |> Map.put(
           :pending_choices,
           Serializer.serialize_choices_list(choices, system, parse_display_mode(msg))
@@ -662,11 +662,11 @@ defmodule ExTTRPGDev.CLI.Server do
       updated = %{character | decisions: character.decisions ++ [decision]}
       Characters.save_character!(updated, true)
 
-      resolved = resolve_character(system, updated)
+      {_effects, resolved} = Characters.resolved_state(system, updated)
       choices = Characters.pending_choices(system, updated, resolved)
 
       data =
-        Serializer.serialize_character(system, updated, slug, parse_display_mode(msg))
+        Serializer.serialize_character(system, updated, slug, parse_display_mode(msg), resolved)
         |> Map.put(
           :pending_choices,
           Serializer.serialize_choices_list(choices, system, parse_display_mode(msg))
@@ -788,12 +788,6 @@ defmodule ExTTRPGDev.CLI.Server do
       {:ok, result} -> result
       {:error, reason} -> raise("failed to add to inventory: #{inspect(reason)}")
     end
-  end
-
-  defp resolve_character(%LoadedSystem{} = system, %Character{} = character) do
-    system
-    |> Characters.active_effects(character)
-    |> then(&Evaluator.evaluate!(system, character.generated_values, &1))
   end
 
   defp load_progression_target!(%LoadedSystem{} = system, progression_id) do


### PR DESCRIPTION
Closes #128.

## What

Two commits:

1. **`refactor(characters): extract resolved_state/2`** — the `active_effects` + `Evaluator.evaluate!` idiom appeared verbatim at four sites in `characters.ex` (six at the time the issue was filed; #127 already collapsed two of them into `resolve_all`). `Characters.resolved_state/2` now owns the pipeline and returns `{effects, resolved}` — a tuple because `compute_pending_choice_slots` needs the effects list afterward for its per-level re-evaluation; the other sites discard it.

2. **`perf(cli): evaluate the DAG once per server mutation request`** — every mutation request (award, resolve_choice, build_finish) evaluated the full DAG twice: the server's `resolve_character/2` once for pending choices, then `Serializer.serialize_character` again internally. `serialize_character/5` now takes an optional precomputed resolved map (falling back to `resolved_state/2` when absent), the five handler sites that already hold one pass it through, and `resolve_character/2` is deleted.

## Notes

- Handlers that never resolved separately (`show`, `build_start`, `random_resolve`) keep using the serializer's internal fallback — they already evaluated once, so threading state through them would be plumbing for no saved work.
- The serializer's optional param is the resolved map, not the `{effects, resolved}` tuple, since it never uses the effects list.
- Per-iteration re-evaluation inside `resolve_all` loops is inherent (effects change between iterations); centralizing in `resolved_state/2` is what makes future memoization possible.

No behavior change; all 389 tests pass unchanged, credo and dialyzer clean.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Introduced `Characters.resolved_state/2` to centralize the computation of active effects and system evaluation.</li>
<li>Refactored character resolution logic across the codebase to use the new `resolved_state/2` function instead of manual evaluation.</li>
<li>Updated `Serializer.serialize_character/5` to accept an optional `resolved` state, reducing redundant re-evaluations.</li>
<li>Removed the private `resolve_character/2` helper function from `CLI.Server` in favor of the new centralized implementation.</li>
</ul></div>