### PR TITLE
refactor(server): dedupe award handlers and mutate-then-report response tail

### DIFF
--- a/apps/ttrpg_dev_cli/lib/cli/server.ex
+++ b/apps/ttrpg_dev_cli/lib/cli/server.ex
@@ -290,32 +290,6 @@ defmodule ExTTRPGDev.CLI.Server do
   end
 
   defp handle(
-         %{
-           "command" => "characters.award",
-           "character" => slug,
-           "award" => award_id,
-           "value" => value
-         } = msg,
-         state
-       ) do
-    character = Characters.load_character!(slug)
-    system = RuleSystems.load_system!(character.metadata.rule_system)
-
-    award_meta =
-      system.concept_metadata[{"award", award_id}] ||
-        raise("unknown award: #{inspect(award_id)}")
-
-    updated = apply_award!(character, award_meta, value)
-    new_slots = Characters.compute_pending_choice_slots(system, updated)
-    updated = %{updated | pending_choice_slots: new_slots}
-    Characters.save_character!(updated, true)
-
-    data = character_with_choices_response(system, updated, slug, msg)
-
-    {ok(data), state}
-  end
-
-  defp handle(
          %{"command" => "characters.award", "character" => slug, "award" => award_id} = msg,
          state
        ) do
@@ -326,8 +300,20 @@ defmodule ExTTRPGDev.CLI.Server do
       system.concept_metadata[{"award", award_id}] ||
         raise("unknown award: #{inspect(award_id)}")
 
-    xp_needed = compute_next_level_xp!(system, character, award_meta)
-    updated = apply_award!(character, award_meta, xp_needed)
+    # Without an explicit value the award is computed (e.g. "level_up" grants
+    # exactly the XP needed for the next level), and the response reports the
+    # computed amount as :awarded_xp.
+    {value, response_extras} =
+      case Map.fetch(msg, "value") do
+        {:ok, value} ->
+          {value, %{}}
+
+        :error ->
+          xp_needed = compute_next_level_xp!(system, character, award_meta)
+          {xp_needed, %{awarded_xp: xp_needed}}
+      end
+
+    updated = apply_award!(character, award_meta, value)
     new_slots = Characters.compute_pending_choice_slots(system, updated)
     updated = %{updated | pending_choice_slots: new_slots}
     Characters.save_character!(updated, true)
@@ -335,7 +321,7 @@ defmodule ExTTRPGDev.CLI.Server do
     data =
       system
       |> character_with_choices_response(updated, slug, msg)
-      |> Map.put(:awarded_xp, xp_needed)
+      |> Map.merge(response_extras)
 
     {ok(data), state}
   end

--- a/apps/ttrpg_dev_cli/lib/cli/server.ex
+++ b/apps/ttrpg_dev_cli/lib/cli/server.ex
@@ -252,11 +252,7 @@ defmodule ExTTRPGDev.CLI.Server do
     updated = %{char | inventory: inv, pending_choice_slots: slots}
     Characters.save_character!(updated)
     new_state = %{state | pending: Map.delete(state.pending, temp_id)}
-    {_effects, resolved} = Characters.resolved_state(sys, updated)
-    choices = Characters.pending_choices(sys, updated, resolved)
-    mode = parse_display_mode(msg)
-    ser = Serializer.serialize_character(sys, updated, updated.metadata.slug, mode, resolved)
-    data = Map.put(ser, :pending_choices, Serializer.serialize_choices_list(choices, sys, mode))
+    data = character_with_choices_response(sys, updated, updated.metadata.slug, msg)
 
     {ok(data), new_state}
   end
@@ -314,15 +310,7 @@ defmodule ExTTRPGDev.CLI.Server do
     updated = %{updated | pending_choice_slots: new_slots}
     Characters.save_character!(updated, true)
 
-    {_effects, resolved} = Characters.resolved_state(system, updated)
-    choices = Characters.pending_choices(system, updated, resolved)
-
-    data =
-      Serializer.serialize_character(system, updated, slug, parse_display_mode(msg), resolved)
-      |> Map.put(
-        :pending_choices,
-        Serializer.serialize_choices_list(choices, system, parse_display_mode(msg))
-      )
+    data = character_with_choices_response(system, updated, slug, msg)
 
     {ok(data), state}
   end
@@ -344,15 +332,9 @@ defmodule ExTTRPGDev.CLI.Server do
     updated = %{updated | pending_choice_slots: new_slots}
     Characters.save_character!(updated, true)
 
-    {_effects, resolved} = Characters.resolved_state(system, updated)
-    choices = Characters.pending_choices(system, updated, resolved)
-
     data =
-      Serializer.serialize_character(system, updated, slug, parse_display_mode(msg), resolved)
-      |> Map.put(
-        :pending_choices,
-        Serializer.serialize_choices_list(choices, system, parse_display_mode(msg))
-      )
+      system
+      |> character_with_choices_response(updated, slug, msg)
       |> Map.put(:awarded_xp, xp_needed)
 
     {ok(data), state}
@@ -438,15 +420,7 @@ defmodule ExTTRPGDev.CLI.Server do
 
     Characters.save_character!(updated, true)
 
-    {_effects, resolved} = Characters.resolved_state(system, updated)
-    choices = Characters.pending_choices(system, updated, resolved)
-
-    data =
-      Serializer.serialize_character(system, updated, slug, parse_display_mode(msg), resolved)
-      |> Map.put(
-        :pending_choices,
-        Serializer.serialize_choices_list(choices, system, parse_display_mode(msg))
-      )
+    data = character_with_choices_response(system, updated, slug, msg)
 
     {ok(data), state}
   end
@@ -593,15 +567,7 @@ defmodule ExTTRPGDev.CLI.Server do
     updated = %{character | decisions: character.decisions ++ [decision]}
     Characters.save_character!(updated, true)
 
-    {_effects, resolved} = Characters.resolved_state(system, updated)
-    choices = Characters.pending_choices(system, updated, resolved)
-
-    data =
-      Serializer.serialize_character(system, updated, slug, parse_display_mode(msg), resolved)
-      |> Map.put(
-        :pending_choices,
-        Serializer.serialize_choices_list(choices, system, parse_display_mode(msg))
-      )
+    data = character_with_choices_response(system, updated, slug, msg)
 
     {ok(data), state}
   end
@@ -792,6 +758,19 @@ defmodule ExTTRPGDev.CLI.Server do
   end
 
   # --- Response helpers ---
+
+  # The standard response body for mutate-then-report handlers: the character
+  # serialized against a single DAG evaluation, plus its recomputed pending
+  # choices rendered in the request's display mode.
+  defp character_with_choices_response(system, character, slug, msg) do
+    {_effects, resolved} = Characters.resolved_state(system, character)
+    choices = Characters.pending_choices(system, character, resolved)
+    mode = parse_display_mode(msg)
+
+    system
+    |> Serializer.serialize_character(character, slug, mode, resolved)
+    |> Map.put(:pending_choices, Serializer.serialize_choices_list(choices, system, mode))
+  end
 
   defp ok(data), do: %{status: "ok", data: data}
   defp error(message), do: %{status: "error", message: message}


### PR DESCRIPTION
Closes #130.

## What

Two commits, one per dedupe target from the issue:

1. **Shared response tail** — the `resolved_state` → `pending_choices` → `serialize_character` → `Map.put(:pending_choices, ...)` sequence was repeated at five handler tails (`build_finish`, both `award` clauses, both `resolve_choice` clauses), four of them calling `parse_display_mode(msg)` twice. `character_with_choices_response/4` now owns the sequence and parses the display mode exactly once per request. (`build_finish` had already drifted into a differently-shaped copy of the same logic — now it's the same call as everyone else.)

2. **One award handler** — the two `characters.award` clauses merged into one that branches on `Map.fetch(msg, "value")`. The branch returns `{value, response_extras}` so the value source and its `:awarded_xp` enrichment stay paired: the key appears only when the server computed the amount, preserving response shapes exactly.

## Notes

- `Map.fetch` rather than `Map.get` preserves an edge case of the old pattern-match dispatch: an explicit JSON `null` value still takes the explicit-value path (failing in `apply_award!`) instead of being reinterpreted as a computed award.
- Net −35 lines across the two commits.

No behavior change; all 389 tests pass unchanged, credo and dialyzer clean.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored character response generation into a new helper function `character_with_choices_response` to reduce code duplication across multiple handlers.</li>
<li>Removed redundant `handle` function for `characters.award` that accepted a specific value, consolidating logic into the main award handler.</li>
<li>Updated `characters.award` handler to dynamically compute award values when not provided, returning the computed amount in the response.</li>
<li>Standardized response structure for character mutation commands (award, decision, etc.) using the new helper.</li>
</ul></div>