### PR TITLE
refactor: move award application and progression choice resolution into the library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ burrito_out
 
 # Local build output (both binaries assembled for testing)
 /build_out/
+
+# Dialyzer PLT cache
+/priv/plts/

--- a/apps/ex_ttrpg_dev/lib/characters.ex
+++ b/apps/ex_ttrpg_dev/lib/characters.ex
@@ -15,6 +15,7 @@ defmodule ExTTRPGDev.Characters do
 
   # Bound to attributes for use in pattern-match positions; the names are
   # owned by ExTTRPGDev.RuleSystem.Vocabulary.
+  @award_type Vocabulary.award_type()
   @progression_type Vocabulary.progression_type()
   @roll_type Vocabulary.roll_type()
 
@@ -196,6 +197,81 @@ defmodule ExTTRPGDev.Characters do
       end
     end
   end
+
+  @doc """
+  Applies an award concept to a character.
+
+  Awards are concepts of the reserved `award` type whose metadata declares a
+  `value_type` (how the awarded value is obtained) and an `effect_target`
+  (the node the value contributes to). Supported value types:
+
+  - `"integer"` — the caller must supply an integer `value`
+  - `"next_level_xp"` — with `value` as `nil`, the library computes the XP
+    needed to reach the character's next level; an explicit `value` takes
+    precedence
+
+  Returns `{:ok, updated_character, awarded_value}` where the updated character
+  carries the new effect and freshly recomputed `pending_choice_slots` (an
+  award may change the character's level and thereby unlock choice slots).
+
+  Error reasons:
+
+  - `{:unknown_award, award_id}`
+  - `{:value_required, value_type}` — the award cannot compute its own value
+  - `:value_must_be_integer`
+  - `{:unsupported_value_type, value_type}`
+  - `:max_level` / `:no_level_thresholds` — from `xp_to_next_level/2`
+  - `:missing_effect_target` / `{:invalid_effect_target, target}`
+  """
+  def apply_award(%LoadedSystem{} = system, %Character{} = character, award_id, value \\ nil) do
+    with {:ok, meta} <- fetch_award_meta(system, award_id),
+         {:ok, awarded} <- award_value(system, character, meta, value),
+         {:ok, target} <- fetch_effect_target(meta) do
+      updated = %{character | effects: character.effects ++ [%{target: target, value: awarded}]}
+      updated = %{updated | pending_choice_slots: compute_pending_choice_slots(system, updated)}
+      {:ok, updated, awarded}
+    end
+  end
+
+  defp fetch_award_meta(system, award_id) do
+    case system.concept_metadata[{@award_type, award_id}] do
+      nil -> {:error, {:unknown_award, award_id}}
+      meta -> {:ok, meta}
+    end
+  end
+
+  defp award_value(_system, _character, %{"value_type" => "integer"}, value)
+       when is_integer(value),
+       do: {:ok, value}
+
+  defp award_value(_system, _character, %{"value_type" => "integer"}, value)
+       when not is_nil(value),
+       do: {:error, :value_must_be_integer}
+
+  defp award_value(system, character, %{"value_type" => "next_level_xp"}, nil) do
+    case xp_to_next_level(system, character) do
+      {:ok, xp_needed, _next_level} -> {:ok, xp_needed}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp award_value(_system, _character, %{"value_type" => "next_level_xp"}, value),
+    do: {:ok, value}
+
+  defp award_value(_system, _character, meta, nil),
+    do: {:error, {:value_required, meta["value_type"]}}
+
+  defp award_value(_system, _character, meta, _value),
+    do: {:error, {:unsupported_value_type, meta["value_type"]}}
+
+  defp fetch_effect_target(%{"effect_target" => target}) when is_binary(target) do
+    case Expression.parse_ref(target) do
+      {:ok, ref} -> {:ok, ref}
+      :error -> {:error, {:invalid_effect_target, target}}
+    end
+  end
+
+  defp fetch_effect_target(_meta), do: {:error, :missing_effect_target}
 
   @doc """
   Returns the current preparation state for the given inventory type.

--- a/apps/ex_ttrpg_dev/lib/characters.ex
+++ b/apps/ex_ttrpg_dev/lib/characters.ex
@@ -227,6 +227,35 @@ defmodule ExTTRPGDev.Characters do
     do: Advancement.apply_award(system, character, award_id, value)
 
   @doc """
+  Resolves a pending progression choice for a character.
+
+  For selection progressions (metadata declares `type`), `selection` must be
+  one of the currently valid options as computed by `pending_choices/3` —
+  already-selected concepts are excluded and slot-level caps applied. The
+  progression's pending choice slot (if any) is consumed, and the selected
+  concept is added to the character's typed inventory when its concept type
+  is configured as one (see `add_to_typed_inventory/4`).
+
+  For value progressions (no `type`), `selection` is a free-form method label
+  recorded on the decision (e.g. `"rolled"` or `"average"`) and `value` must
+  be an integer contributed to the progression's `effect_target`. Value
+  progressions are not validated against pending state; callers that need
+  that bookkeeping drive them from `pending_choices/3` themselves.
+
+  Returns `{:ok, updated_character}` or `{:error, reason}`:
+
+  - `{:unknown_progression, progression_id}`
+  - `{:no_pending_choice, progression_id}` — selection progression with nothing pending
+  - `{:invalid_selection, selection}`
+  - `:value_required` / `:value_must_be_integer`
+  - `:missing_effect_target` / `{:invalid_effect_target, target}`
+  - `{:inventory_error, reason}` — from `add_to_typed_inventory/4`
+  """
+  def resolve_progression_choice(system, character, progression_id, selection, value \\ nil),
+    do:
+      Advancement.resolve_progression_choice(system, character, progression_id, selection, value)
+
+  @doc """
   Returns the current preparation state for the given inventory type.
 
   Computes mode, cap, eligible pool, always-prepared items, and currently
@@ -1053,10 +1082,12 @@ defmodule ExTTRPGDev.Characters do
 
   defp progression_choices(_id, _meta, _decisions, _resolved), do: []
 
-  # The single constructor for progression decisions: computes the next
-  # 1-based choice number from the decisions already made and builds the
-  # canonical decision map.
-  defp next_progression_decision(decisions, progression_id, selection) do
+  @doc """
+  The single constructor for progression decisions: computes the next 1-based
+  choice number from the decisions already made and builds the canonical
+  decision map for `progression_id`.
+  """
+  def next_progression_decision(decisions, progression_id, selection) do
     n = count_progression_decisions(decisions, progression_id) + 1
 
     %{

--- a/apps/ex_ttrpg_dev/lib/characters.ex
+++ b/apps/ex_ttrpg_dev/lib/characters.ex
@@ -3,6 +3,7 @@ defmodule ExTTRPGDev.Characters do
   This module handles handles character operations
   """
   alias DiceLib.Basic, as: Dice
+  alias ExTTRPGDev.Characters.Advancement
   alias ExTTRPGDev.Characters.Character
   alias ExTTRPGDev.Characters.Metadata
   alias ExTTRPGDev.Characters.InventoryItem
@@ -15,7 +16,6 @@ defmodule ExTTRPGDev.Characters do
 
   # Bound to attributes for use in pattern-match positions; the names are
   # owned by ExTTRPGDev.RuleSystem.Vocabulary.
-  @award_type Vocabulary.award_type()
   @progression_type Vocabulary.progression_type()
   @roll_type Vocabulary.roll_type()
 
@@ -223,55 +223,8 @@ defmodule ExTTRPGDev.Characters do
   - `:max_level` / `:no_level_thresholds` — from `xp_to_next_level/2`
   - `:missing_effect_target` / `{:invalid_effect_target, target}`
   """
-  def apply_award(%LoadedSystem{} = system, %Character{} = character, award_id, value \\ nil) do
-    with {:ok, meta} <- fetch_award_meta(system, award_id),
-         {:ok, awarded} <- award_value(system, character, meta, value),
-         {:ok, target} <- fetch_effect_target(meta) do
-      updated = %{character | effects: character.effects ++ [%{target: target, value: awarded}]}
-      updated = %{updated | pending_choice_slots: compute_pending_choice_slots(system, updated)}
-      {:ok, updated, awarded}
-    end
-  end
-
-  defp fetch_award_meta(system, award_id) do
-    case system.concept_metadata[{@award_type, award_id}] do
-      nil -> {:error, {:unknown_award, award_id}}
-      meta -> {:ok, meta}
-    end
-  end
-
-  defp award_value(_system, _character, %{"value_type" => "integer"}, value)
-       when is_integer(value),
-       do: {:ok, value}
-
-  defp award_value(_system, _character, %{"value_type" => "integer"}, value)
-       when not is_nil(value),
-       do: {:error, :value_must_be_integer}
-
-  defp award_value(system, character, %{"value_type" => "next_level_xp"}, nil) do
-    case xp_to_next_level(system, character) do
-      {:ok, xp_needed, _next_level} -> {:ok, xp_needed}
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  defp award_value(_system, _character, %{"value_type" => "next_level_xp"}, value),
-    do: {:ok, value}
-
-  defp award_value(_system, _character, meta, nil),
-    do: {:error, {:value_required, meta["value_type"]}}
-
-  defp award_value(_system, _character, meta, _value),
-    do: {:error, {:unsupported_value_type, meta["value_type"]}}
-
-  defp fetch_effect_target(%{"effect_target" => target}) when is_binary(target) do
-    case Expression.parse_ref(target) do
-      {:ok, ref} -> {:ok, ref}
-      :error -> {:error, {:invalid_effect_target, target}}
-    end
-  end
-
-  defp fetch_effect_target(_meta), do: {:error, :missing_effect_target}
+  def apply_award(system, character, award_id, value \\ nil),
+    do: Advancement.apply_award(system, character, award_id, value)
 
   @doc """
   Returns the current preparation state for the given inventory type.

--- a/apps/ex_ttrpg_dev/lib/characters/advancement.ex
+++ b/apps/ex_ttrpg_dev/lib/characters/advancement.ex
@@ -1,0 +1,79 @@
+defmodule ExTTRPGDev.Characters.Advancement do
+  @moduledoc """
+  Character advancement: applying award concepts to characters.
+
+  Callers should use the delegating functions on `ExTTRPGDev.Characters`
+  (e.g. `ExTTRPGDev.Characters.apply_award/4`); this module hosts the
+  implementation.
+  """
+
+  alias ExTTRPGDev.Characters
+  alias ExTTRPGDev.Characters.Character
+  alias ExTTRPGDev.RuleSystem.Expression
+  alias ExTTRPGDev.RuleSystem.Vocabulary
+  alias ExTTRPGDev.RuleSystems.LoadedSystem
+
+  # Bound to attributes for use in pattern-match positions; the names are
+  # owned by ExTTRPGDev.RuleSystem.Vocabulary.
+  @award_type Vocabulary.award_type()
+
+  @doc """
+  Applies an award concept to a character.
+
+  See `ExTTRPGDev.Characters.apply_award/4` for documentation.
+  """
+  def apply_award(%LoadedSystem{} = system, %Character{} = character, award_id, value \\ nil) do
+    with {:ok, meta} <- fetch_award_meta(system, award_id),
+         {:ok, awarded} <- award_value(system, character, meta, value),
+         {:ok, target} <- fetch_effect_target(meta) do
+      updated = %{character | effects: character.effects ++ [%{target: target, value: awarded}]}
+
+      updated = %{
+        updated
+        | pending_choice_slots: Characters.compute_pending_choice_slots(system, updated)
+      }
+
+      {:ok, updated, awarded}
+    end
+  end
+
+  defp fetch_award_meta(system, award_id) do
+    case system.concept_metadata[{@award_type, award_id}] do
+      nil -> {:error, {:unknown_award, award_id}}
+      meta -> {:ok, meta}
+    end
+  end
+
+  defp award_value(_system, _character, %{"value_type" => "integer"}, value)
+       when is_integer(value),
+       do: {:ok, value}
+
+  defp award_value(_system, _character, %{"value_type" => "integer"}, value)
+       when not is_nil(value),
+       do: {:error, :value_must_be_integer}
+
+  defp award_value(system, character, %{"value_type" => "next_level_xp"}, nil) do
+    case Characters.xp_to_next_level(system, character) do
+      {:ok, xp_needed, _next_level} -> {:ok, xp_needed}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp award_value(_system, _character, %{"value_type" => "next_level_xp"}, value),
+    do: {:ok, value}
+
+  defp award_value(_system, _character, meta, nil),
+    do: {:error, {:value_required, meta["value_type"]}}
+
+  defp award_value(_system, _character, meta, _value),
+    do: {:error, {:unsupported_value_type, meta["value_type"]}}
+
+  defp fetch_effect_target(%{"effect_target" => target}) when is_binary(target) do
+    case Expression.parse_ref(target) do
+      {:ok, ref} -> {:ok, ref}
+      :error -> {:error, {:invalid_effect_target, target}}
+    end
+  end
+
+  defp fetch_effect_target(_meta), do: {:error, :missing_effect_target}
+end

--- a/apps/ex_ttrpg_dev/lib/characters/advancement.ex
+++ b/apps/ex_ttrpg_dev/lib/characters/advancement.ex
@@ -1,6 +1,7 @@
 defmodule ExTTRPGDev.Characters.Advancement do
   @moduledoc """
-  Character advancement: applying award concepts to characters.
+  Character advancement: applying award concepts and resolving progression
+  choices.
 
   Callers should use the delegating functions on `ExTTRPGDev.Characters`
   (e.g. `ExTTRPGDev.Characters.apply_award/4`); this module hosts the
@@ -16,6 +17,7 @@ defmodule ExTTRPGDev.Characters.Advancement do
   # Bound to attributes for use in pattern-match positions; the names are
   # owned by ExTTRPGDev.RuleSystem.Vocabulary.
   @award_type Vocabulary.award_type()
+  @progression_type Vocabulary.progression_type()
 
   @doc """
   Applies an award concept to a character.
@@ -76,4 +78,89 @@ defmodule ExTTRPGDev.Characters.Advancement do
   end
 
   defp fetch_effect_target(_meta), do: {:error, :missing_effect_target}
+
+  @doc """
+  Resolves a pending progression choice for a character.
+
+  See `ExTTRPGDev.Characters.resolve_progression_choice/5` for documentation.
+  """
+  def resolve_progression_choice(system, character, progression_id, selection, value \\ nil)
+
+  def resolve_progression_choice(
+        %LoadedSystem{} = system,
+        %Character{} = character,
+        progression_id,
+        selection,
+        value
+      ) do
+    case system.concept_metadata[{@progression_type, progression_id}] do
+      nil ->
+        {:error, {:unknown_progression, progression_id}}
+
+      %{"type" => _} ->
+        resolve_selection_progression(system, character, progression_id, selection)
+
+      meta ->
+        resolve_value_progression(character, progression_id, meta, {selection, value})
+    end
+  end
+
+  defp resolve_selection_progression(system, character, progression_id, selection) do
+    {_effects, resolved} = Characters.resolved_state(system, character)
+    choices = Characters.pending_choices(system, character, resolved)
+
+    entry =
+      Enum.find(choices, fn c ->
+        c.type == :pending and c.id == progression_id and not Map.has_key?(c, :scope_type)
+      end)
+
+    cond do
+      entry == nil ->
+        {:error, {:no_pending_choice, progression_id}}
+
+      selection not in entry.options ->
+        {:error, {:invalid_selection, selection}}
+
+      true ->
+        decision =
+          Characters.next_progression_decision(character.decisions, progression_id, selection)
+
+        with_decision = %{
+          character
+          | decisions: character.decisions ++ [decision],
+            pending_choice_slots: consume_slot(character.pending_choice_slots, progression_id)
+        }
+
+        case Characters.add_to_typed_inventory(system, with_decision, progression_id, selection) do
+          {:ok, updated} -> {:ok, updated}
+          {:error, reason} -> {:error, {:inventory_error, reason}}
+        end
+    end
+  end
+
+  defp resolve_value_progression(character, progression_id, meta, {selection, value}) do
+    with :ok <- validate_progression_value(value),
+         {:ok, target} <- fetch_effect_target(meta) do
+      decision =
+        Characters.next_progression_decision(character.decisions, progression_id, selection)
+
+      {:ok,
+       %{
+         character
+         | effects: character.effects ++ [%{target: target, value: value}],
+           decisions: character.decisions ++ [decision]
+       }}
+    end
+  end
+
+  defp validate_progression_value(value) when is_integer(value), do: :ok
+  defp validate_progression_value(nil), do: {:error, :value_required}
+  defp validate_progression_value(_), do: {:error, :value_must_be_integer}
+
+  defp consume_slot(pending_choice_slots, progression_id) do
+    case Enum.split_while(pending_choice_slots, &(&1.progression_id != progression_id)) do
+      {before_slots, [_ | after_slots]} -> before_slots ++ after_slots
+      _ -> pending_choice_slots
+    end
+  end
 end

--- a/apps/ex_ttrpg_dev/lib/rule_system/loader.ex
+++ b/apps/ex_ttrpg_dev/lib/rule_system/loader.ex
@@ -23,12 +23,21 @@ defmodule ExTTRPGDev.RuleSystem.Loader do
 
   ### Reserved concept type IDs
 
-  Three concept type IDs have structural meaning to the library:
+  Four concept type IDs have structural meaning to the library:
 
   - `"roll"` — concepts of this type define die rolling methods. Each must have
     `target_type`, `dice`, and `bonus_field` (see below).
   - `"character_progression"` — concepts of this type define character advancement
     tables. The library uses this type ID to locate progression decisions.
+  - `"award"` — concepts of this type define grantable awards applied via
+    `ExTTRPGDev.Characters.apply_award/4`. Keys:
+    - `"value_type"` *(string, required)* — how the awarded value is obtained:
+      `"integer"` (the caller must supply an integer value) or `"next_level_xp"`
+      (the library computes the XP needed to reach the character's next level;
+      an explicitly supplied value takes precedence).
+    - `"effect_target"` *(expression string, required)* — node key expression the
+      awarded value contributes to (e.g.
+      `"character_trait('experience_points').total"`).
   - `"rolling_method"` — concepts of this type define how `generated` nodes are
     rolled at character generation. Keys:
     - `"name"` *(string, optional)* — display name.

--- a/apps/ex_ttrpg_dev/lib/rule_system/vocabulary.ex
+++ b/apps/ex_ttrpg_dev/lib/rule_system/vocabulary.ex
@@ -13,6 +13,7 @@ defmodule ExTTRPGDev.RuleSystem.Vocabulary do
   attribute at compile time (e.g. `@progression_type Vocabulary.progression_type()`).
   """
 
+  @award_type "award"
   @progression_type "character_progression"
   @roll_type "roll"
   @rolling_method_type "rolling_method"
@@ -25,8 +26,11 @@ defmodule ExTTRPGDev.RuleSystem.Vocabulary do
   @structural_metadata_keys ~w(
     name type required_count available_when effect_target roll_reference roll
     filter choices level requires starting_equipment target_type dice bonus_field
-    contributes hidden
+    contributes hidden value_type
   )
+
+  @doc "Reserved type ID for award concepts (XP grants, level-ups)."
+  def award_type, do: @award_type
 
   @doc "Reserved type ID for character advancement (progression) concepts."
   def progression_type, do: @progression_type

--- a/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/module.toml
+++ b/apps/ex_ttrpg_dev/priv/system_configs/dnd_5e_srd/module.toml
@@ -9,8 +9,6 @@ level_node = "character_trait('character_level').level"
 custom_metadata_keys = [
   # ability / skill display
   "abbreviation", "description",
-  # award
-  "value_type",
   # background / race
   "skill_proficiencies", "damage_resistances", "languages",
   # character_trait

--- a/apps/ex_ttrpg_dev/test/characters/apply_award_test.exs
+++ b/apps/ex_ttrpg_dev/test/characters/apply_award_test.exs
@@ -1,0 +1,76 @@
+defmodule ExTTRPGDevTest.Characters.ApplyAward do
+  use ExUnit.Case, async: true
+  alias ExTTRPGDev.Characters
+  alias ExTTRPGDev.Characters.Character
+  alias ExTTRPGDev.RuleSystems
+
+  setup do
+    system = RuleSystems.load_system!("dnd_5e_srd")
+    {:ok, system: system, character: Character.gen_character!(system)}
+  end
+
+  defp xp_effect(amount),
+    do: %{target: {"character_trait", "experience_points", "total"}, value: amount}
+
+  test "integer award with an explicit value appends the effect and returns the value",
+       %{system: system, character: character} do
+    assert {:ok, updated, 300} =
+             Characters.apply_award(system, character, "experience_points", 300)
+
+    assert xp_effect(300) in updated.effects
+  end
+
+  test "integer award without a value is rejected", %{system: system, character: character} do
+    assert {:error, {:value_required, "integer"}} =
+             Characters.apply_award(system, character, "experience_points", nil)
+  end
+
+  test "integer award with a non-integer value is rejected",
+       %{system: system, character: character} do
+    assert {:error, :value_must_be_integer} =
+             Characters.apply_award(system, character, "experience_points", "300")
+  end
+
+  test "next_level_xp award computes the XP needed for the next level",
+       %{system: system, character: character} do
+    # level 1 with no XP: level 2 requires exactly 300 XP
+    assert {:ok, updated, 300} = Characters.apply_award(system, character, "level_up", nil)
+    assert xp_effect(300) in updated.effects
+  end
+
+  test "next_level_xp award prefers an explicitly supplied value",
+       %{system: system, character: character} do
+    assert {:ok, updated, 42} = Characters.apply_award(system, character, "level_up", 42)
+    assert xp_effect(42) in updated.effects
+  end
+
+  test "next_level_xp award at max level returns :max_level",
+       %{system: system, character: character} do
+    character = %{character | effects: [xp_effect(305_000)]}
+    assert {:error, :max_level} = Characters.apply_award(system, character, "level_up", nil)
+  end
+
+  test "unknown award id is rejected", %{system: system, character: character} do
+    assert {:error, {:unknown_award, "nonexistent"}} =
+             Characters.apply_award(system, character, "nonexistent", 1)
+  end
+
+  test "recomputes pending choice slots for the awarded state", %{system: system} do
+    decisions = [%{scope: nil, choice: "class", selection: "wizard"}]
+    character = Character.gen_character!(system, decisions)
+
+    character = %{
+      character
+      | pending_choice_slots: Characters.compute_pending_choice_slots(system, character)
+    }
+
+    # 6500 XP puts the wizard at level 5, unlocking additional spells_known slots
+    assert {:ok, updated, 6500} =
+             Characters.apply_award(system, character, "experience_points", 6500)
+
+    assert updated.pending_choice_slots ==
+             Characters.compute_pending_choice_slots(system, updated)
+
+    assert length(updated.pending_choice_slots) > length(character.pending_choice_slots)
+  end
+end

--- a/apps/ex_ttrpg_dev/test/characters/resolve_progression_choice_test.exs
+++ b/apps/ex_ttrpg_dev/test/characters/resolve_progression_choice_test.exs
@@ -1,0 +1,135 @@
+defmodule ExTTRPGDevTest.Characters.ResolveProgressionChoice do
+  use ExUnit.Case, async: true
+  alias ExTTRPGDev.Characters
+  alias ExTTRPGDev.Characters.Character
+  alias ExTTRPGDev.RuleSystems
+
+  setup do
+    system = RuleSystems.load_system!("dnd_5e_srd")
+
+    decisions = [
+      %{scope: nil, choice: "class", selection: "wizard"},
+      %{scope: nil, choice: "race", selection: "human"},
+      %{scope: nil, choice: "background", selection: "soldier"}
+    ]
+
+    character = Character.gen_character!(system, decisions)
+
+    character = %{
+      character
+      | pending_choice_slots: Characters.compute_pending_choice_slots(system, character)
+    }
+
+    {:ok, system: system, character: character}
+  end
+
+  defp pending_options(system, character, progression_id) do
+    {_effects, resolved} = Characters.resolved_state(system, character)
+
+    system
+    |> Characters.pending_choices(character, resolved)
+    |> Enum.find(&(&1.id == progression_id and not Map.has_key?(&1, :scope_type)))
+    |> Map.fetch!(:options)
+  end
+
+  test "resolving a valid selection records the decision and adds to inventory", ctx do
+    [cantrip | _] = pending_options(ctx.system, ctx.character, "cantrips")
+
+    assert {:ok, updated} =
+             Characters.resolve_progression_choice(ctx.system, ctx.character, "cantrips", cantrip)
+
+    assert %{
+             scope: {"character_progression", "cantrips"},
+             choice: "choice_1",
+             selection: ^cantrip
+           } = List.last(updated.decisions)
+
+    assert Enum.any?(updated.inventory, &(&1.concept_id == cantrip))
+  end
+
+  test "an already-selected concept is no longer a valid option", ctx do
+    [cantrip | _] = pending_options(ctx.system, ctx.character, "cantrips")
+
+    {:ok, updated} =
+      Characters.resolve_progression_choice(ctx.system, ctx.character, "cantrips", cantrip)
+
+    assert {:error, {:invalid_selection, ^cantrip}} =
+             Characters.resolve_progression_choice(ctx.system, updated, "cantrips", cantrip)
+  end
+
+  test "a selection outside the valid options is rejected", ctx do
+    # fireball is a level 3 spell, never a cantrip option
+    assert {:error, {:invalid_selection, "fireball"}} =
+             Characters.resolve_progression_choice(
+               ctx.system,
+               ctx.character,
+               "cantrips",
+               "fireball"
+             )
+  end
+
+  test "a selection progression with nothing pending is rejected", ctx do
+    # asi_or_feat requires no choices at level 1 (asi_count is 0)
+    assert {:error, {:no_pending_choice, "asi_or_feat"}} =
+             Characters.resolve_progression_choice(
+               ctx.system,
+               ctx.character,
+               "asi_or_feat",
+               "ability_score_improvement"
+             )
+  end
+
+  test "unknown progression id is rejected", ctx do
+    assert {:error, {:unknown_progression, "nonexistent"}} =
+             Characters.resolve_progression_choice(ctx.system, ctx.character, "nonexistent", "x")
+  end
+
+  test "consumes the pending choice slot for the resolved progression", ctx do
+    slots_before =
+      Enum.count(ctx.character.pending_choice_slots, &(&1.progression_id == "spells_known"))
+
+    assert slots_before > 0
+
+    [spell | _] = pending_options(ctx.system, ctx.character, "spells_known")
+
+    {:ok, updated} =
+      Characters.resolve_progression_choice(ctx.system, ctx.character, "spells_known", spell)
+
+    assert Enum.count(updated.pending_choice_slots, &(&1.progression_id == "spells_known")) ==
+             slots_before - 1
+  end
+
+  test "value progression applies the value to its effect target", ctx do
+    assert {:ok, updated} =
+             Characters.resolve_progression_choice(
+               ctx.system,
+               ctx.character,
+               "hp_per_level",
+               "rolled",
+               7
+             )
+
+    assert %{target: {"character_trait", "max_hit_points", "points"}, value: 7} in updated.effects
+
+    assert %{
+             scope: {"character_progression", "hp_per_level"},
+             choice: "choice_1",
+             selection: "rolled"
+           } = List.last(updated.decisions)
+  end
+
+  test "value progression requires an integer value", ctx do
+    resolve_hp = fn value ->
+      Characters.resolve_progression_choice(
+        ctx.system,
+        ctx.character,
+        "hp_per_level",
+        "rolled",
+        value
+      )
+    end
+
+    assert {:error, :value_required} = resolve_hp.(nil)
+    assert {:error, :value_must_be_integer} = resolve_hp.("7")
+  end
+end

--- a/apps/ttrpg_dev_cli/lib/cli/server.ex
+++ b/apps/ttrpg_dev_cli/lib/cli/server.ex
@@ -295,35 +295,26 @@ defmodule ExTTRPGDev.CLI.Server do
        ) do
     character = Characters.load_character!(slug)
     system = RuleSystems.load_system!(character.metadata.rule_system)
+    explicit_value = Map.get(msg, "value")
 
-    award_meta =
-      system.concept_metadata[{"award", award_id}] ||
-        raise("unknown award: #{inspect(award_id)}")
+    case Characters.apply_award(system, character, award_id, explicit_value) do
+      {:ok, updated, awarded_value} ->
+        Characters.save_character!(updated, true)
 
-    # Without an explicit value the award is computed (e.g. "level_up" grants
-    # exactly the XP needed for the next level), and the response reports the
-    # computed amount as :awarded_xp.
-    {value, response_extras} =
-      case Map.fetch(msg, "value") do
-        {:ok, value} ->
-          {value, %{}}
+        # The response reports :awarded_xp only when the award computed its
+        # own amount (e.g. "level_up") rather than receiving an explicit one.
+        extras = if explicit_value == nil, do: %{awarded_xp: awarded_value}, else: %{}
 
-        :error ->
-          xp_needed = compute_next_level_xp!(system, character, award_meta)
-          {xp_needed, %{awarded_xp: xp_needed}}
-      end
+        data =
+          system
+          |> character_with_choices_response(updated, slug, msg)
+          |> Map.merge(extras)
 
-    updated = apply_award!(character, award_meta, value)
-    new_slots = Characters.compute_pending_choice_slots(system, updated)
-    updated = %{updated | pending_choice_slots: new_slots}
-    Characters.save_character!(updated, true)
+        {ok(data), state}
 
-    data =
-      system
-      |> character_with_choices_response(updated, slug, msg)
-      |> Map.merge(response_extras)
-
-    {ok(data), state}
+      {:error, reason} ->
+        {error(format_award_error(reason)), state}
+    end
   end
 
   defp handle(%{"command" => "characters.choices", "character" => slug} = msg, state) do
@@ -698,38 +689,25 @@ defmodule ExTTRPGDev.CLI.Server do
     end
   end
 
-  defp apply_award!(character, %{"value_type" => "integer", "effect_target" => target}, value) do
-    unless is_integer(value), do: raise("value must be an integer for this award")
-    parsed_target = parse_effect_target!(target)
-    %{character | effects: character.effects ++ [%{target: parsed_target, value: value}]}
-  end
+  defp format_award_error({:unknown_award, id}), do: "unknown award: #{inspect(id)}"
 
-  defp apply_award!(
-         character,
-         %{"value_type" => "next_level_xp", "effect_target" => target},
-         xp_needed
-       ) do
-    parsed_target = parse_effect_target!(target)
-    %{character | effects: character.effects ++ [%{target: parsed_target, value: xp_needed}]}
-  end
-
-  defp apply_award!(_character, %{"value_type" => value_type}, _value) do
-    raise("unsupported award value_type: #{inspect(value_type)}")
-  end
-
-  defp compute_next_level_xp!(system, character, %{"value_type" => "next_level_xp"}) do
-    case Characters.xp_to_next_level(system, character) do
-      {:ok, xp_needed, _next_level} -> xp_needed
-      {:error, :max_level} -> raise("character is already at max level")
-      {:error, :no_level_thresholds} -> raise("system does not define level XP thresholds")
-    end
-  end
-
-  defp compute_next_level_xp!(_system, _character, %{"value_type" => value_type}) do
-    raise(
+  defp format_award_error({:value_required, value_type}),
+    do:
       "award #{inspect(value_type)} requires an explicit value; use: characters award <slug> #{value_type} <value>"
-    )
-  end
+
+  defp format_award_error(:value_must_be_integer), do: "value must be an integer for this award"
+  defp format_award_error(:max_level), do: "character is already at max level"
+
+  defp format_award_error(:no_level_thresholds),
+    do: "system does not define level XP thresholds"
+
+  defp format_award_error({:unsupported_value_type, value_type}),
+    do: "unsupported award value_type: #{inspect(value_type)}"
+
+  defp format_award_error(:missing_effect_target), do: "award has no effect_target"
+
+  defp format_award_error({:invalid_effect_target, target}),
+    do: "invalid effect target: #{inspect(target)}"
 
   defp fetch_pending!(state, temp_id) do
     Map.get(state.pending, temp_id) || raise("no pending character: #{inspect(temp_id)}")

--- a/apps/ttrpg_dev_cli/lib/cli/server.ex
+++ b/apps/ttrpg_dev_cli/lib/cli/server.ex
@@ -47,9 +47,8 @@ defmodule ExTTRPGDev.CLI.Server do
   alias ExTTRPGDev.Characters
   alias ExTTRPGDev.Characters.{Character, InventoryItem}
   alias ExTTRPGDev.CLI.Serializer
-  alias ExTTRPGDev.RuleSystem.{Expression, InventoryRules}
+  alias ExTTRPGDev.RuleSystem.InventoryRules
   alias ExTTRPGDev.RuleSystems
-  alias ExTTRPGDev.RuleSystems.LoadedSystem
 
   @type state :: %{pending: %{String.t() => Character.t()}, next_id: non_neg_integer()}
 
@@ -342,64 +341,20 @@ defmodule ExTTRPGDev.CLI.Server do
     character = Characters.load_character!(slug)
     system = RuleSystems.load_system!(character.metadata.rule_system)
 
-    meta =
-      system.concept_metadata[{"character_progression", progression_id}] ||
-        raise("unknown progression: #{inspect(progression_id)}")
+    case Characters.resolve_progression_choice(
+           system,
+           character,
+           progression_id,
+           selection,
+           Map.get(msg, "value")
+         ) do
+      {:ok, updated} ->
+        Characters.save_character!(updated, true)
+        {ok(character_with_choices_response(system, updated, slug, msg)), state}
 
-    choice_number =
-      Enum.count(character.decisions, fn
-        %{scope: {"character_progression", ^progression_id}} -> true
-        _ -> false
-      end) + 1
-
-    decision = %{
-      scope: {"character_progression", progression_id},
-      choice: "choice_#{choice_number}",
-      selection: selection
-    }
-
-    updated =
-      if Map.has_key?(meta, "type") do
-        {_effects, resolved} = Characters.resolved_state(system, character)
-        active = Characters.active_concepts(character.decisions, system.concept_metadata)
-
-        already_selected =
-          character.decisions
-          |> Enum.filter(fn d -> d.scope == {"character_progression", progression_id} end)
-          |> MapSet.new(& &1.selection)
-
-        capped_resolved = cap_resolved_for_slot(character, progression_id, meta, resolved)
-
-        options =
-          Characters.concept_options(meta, system.concept_metadata, active, capped_resolved)
-          |> Enum.reject(&MapSet.member?(already_selected, &1))
-
-        validate_concept_selection!(selection, options)
-
-        with_decision = %{
-          character
-          | decisions: character.decisions ++ [decision],
-            pending_choice_slots: consume_slot(character.pending_choice_slots, progression_id)
-        }
-
-        apply_inventory_addition!(system, with_decision, progression_id, selection)
-      else
-        value = Map.fetch!(msg, "value")
-        unless is_integer(value), do: raise("value must be an integer")
-        parsed_target = load_progression_target!(system, progression_id)
-
-        %{
-          character
-          | effects: character.effects ++ [%{target: parsed_target, value: value}],
-            decisions: character.decisions ++ [decision]
-        }
-      end
-
-    Characters.save_character!(updated, true)
-
-    data = character_with_choices_response(system, updated, slug, msg)
-
-    {ok(data), state}
+      {:error, reason} ->
+        {error(format_resolve_error(reason)), state}
+    end
   end
 
   defp handle(%{"command" => "characters.random_resolve", "character" => slug} = msg, state) do
@@ -646,48 +601,30 @@ defmodule ExTTRPGDev.CLI.Server do
   defp format_activate_error(:no_preparation_cap), do: "class has no preparation cap"
   defp format_activate_error(reason), do: inspect(reason)
 
-  defp apply_inventory_addition!(system, character, progression_id, selection) do
-    case Characters.add_to_typed_inventory(system, character, progression_id, selection) do
-      {:ok, result} -> result
-      {:error, reason} -> raise("failed to add to inventory: #{inspect(reason)}")
-    end
-  end
-
-  defp load_progression_target!(%LoadedSystem{} = system, progression_id) do
-    meta =
-      system.concept_metadata[{"character_progression", progression_id}] ||
-        raise("unknown progression: #{inspect(progression_id)}")
-
-    effect_target = meta["effect_target"] || raise("progression has no effect_target")
-    parse_effect_target!(effect_target)
-  end
-
   defp validate_concept_selection!(selection, valid_options) do
     unless selection in valid_options do
       raise("#{inspect(selection)} is not available for this character and progression")
     end
   end
 
-  defp parse_effect_target!(target) do
-    case Expression.parse_ref(target) do
-      {:ok, ref} -> ref
-      :error -> raise("invalid effect target: #{inspect(target)}")
-    end
-  end
+  defp format_resolve_error({:unknown_progression, id}),
+    do: "unknown progression: #{inspect(id)}"
 
-  defp cap_resolved_for_slot(character, progression_id, meta, resolved) do
-    case Enum.find(character.pending_choice_slots, &(&1.progression_id == progression_id)) do
-      %{max_level_cap: cap} -> Characters.apply_slot_cap(resolved, meta, cap)
-      nil -> resolved
-    end
-  end
+  defp format_resolve_error({:no_pending_choice, id}),
+    do: "no pending choice for progression: #{inspect(id)}"
 
-  defp consume_slot(pending_choice_slots, progression_id) do
-    case Enum.split_while(pending_choice_slots, &(&1.progression_id != progression_id)) do
-      {before_slots, [_ | after_slots]} -> before_slots ++ after_slots
-      _ -> pending_choice_slots
-    end
-  end
+  defp format_resolve_error({:invalid_selection, selection}),
+    do: "#{inspect(selection)} is not available for this character and progression"
+
+  defp format_resolve_error(:value_required), do: "value is required for this progression"
+  defp format_resolve_error(:value_must_be_integer), do: "value must be an integer"
+  defp format_resolve_error(:missing_effect_target), do: "progression has no effect_target"
+
+  defp format_resolve_error({:invalid_effect_target, target}),
+    do: "invalid effect target: #{inspect(target)}"
+
+  defp format_resolve_error({:inventory_error, reason}),
+    do: "failed to add to inventory: #{inspect(reason)}"
 
   defp format_award_error({:unknown_award, id}), do: "unknown award: #{inspect(id)}"
 


### PR DESCRIPTION
Closes #131.

## What

Business logic that lived in the JSON server moves into the library, in three commits:

1. **`Characters.apply_award/4`** — owns award lookup, `value_type` interpretation (`"integer"` / `"next_level_xp"`), effect construction, and pending-choice-slot recompute (awards can level a character up, so the returned character always has consistent slots). `Vocabulary` gains the reserved `"award"` type ID, `value_type` joins the structural metadata keys (documented in the Loader moduledoc), and it's removed from dnd_5e_srd's `custom_metadata_keys` where it was parked while the server owned the interpretation. `apply_award!` and `compute_next_level_xp!` are deleted from the server.

2. **Extract `Characters.Advancement`** — `characters.ex` sits at its code-health size threshold, so the advancement area gets its own module before growing. `Characters.apply_award/4` stays the public entry point.

3. **`Characters.resolve_progression_choice/4,5`** — selection progressions now validate against the `pending_choices/3` entry, the single source of truth for valid options (already-selected exclusion and slot caps included), instead of the server's parallel re-derivation. `cap_resolved_for_slot`, `consume_slot`, `load_progression_target!`, `parse_effect_target!`, and `apply_inventory_addition!` are deleted from the server; both handlers are now load / call library / save / serialize plus error-message formatting. `next_progression_decision/3` becomes public as the canonical decision constructor.

## Behavior notes (details in commit messages)

- Over-resolving a selection progression (nothing pending) is now rejected with `{:no_pending_choice, id}`; the old path would accept resolutions beyond `required_count`. No client or test relied on that.
- An explicit JSON `null` award value is now treated as "compute the value" rather than applied verbatim (the old behavior stored `null` as an effect value — a latent evaluator crash).
- Value progressions stay deliberately unvalidated against pending state, matching old behavior (documented on the function).

## Tests

17 new library tests in `test/characters/apply_award_test.exs` and `test/characters/resolve_progression_choice_test.exs` (new files — `characters_test.exs` is at its size threshold). All 382 existing tests pass unchanged; credo and dialyzer clean.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Introduced character advancement features including award application and progression choice resolution.</li>
<li>Added `ExTTRPGDev.Characters.Advancement` module to handle the implementation of advancement logic.</li>
<li>Updated `ExTTRPGDev.Characters` to delegate advancement operations to the new module.</li>
<li>Added support for a new reserved concept type 'award' in the rule system loader.</li>
<li>Updated `.gitignore` to include Dialyzer PLT cache directory.</li>
</ul></div>