### PR TITLE
refactor(server): split dispatch into handler modules and standardize error formatting

### DIFF
--- a/apps/ex_ttrpg_dev/lib/characters.ex
+++ b/apps/ex_ttrpg_dev/lib/characters.ex
@@ -256,6 +256,31 @@ defmodule ExTTRPGDev.Characters do
       Advancement.resolve_progression_choice(system, character, progression_id, selection, value)
 
   @doc """
+  Fetches the definition map of the sub-choice `choice_id` declared by the
+  concept at `scope` (`{concept_type, concept_id}`).
+
+  Raises if the concept declares no such choice.
+  """
+  def fetch_choice_def!(system, scope, choice_id),
+    do: Advancement.fetch_choice_def!(system, scope, choice_id)
+
+  @doc """
+  Returns the currently valid selections for a concept sub-choice: the
+  choice's options (see `sub_choice_options/2`) minus selections already made
+  for same-type choices under the same scope (siblings share an exclusion
+  pool — two skill-proficiency choices cannot both pick the same skill).
+  """
+  def valid_sub_choices(system, scope, choice_def, decisions),
+    do: Advancement.valid_sub_choices(system, scope, choice_def, decisions)
+
+  @doc """
+  The raw option list for a sub-choice definition: its declared `options`
+  list, or every concept of the choice's `type` when none is declared.
+  """
+  def sub_choice_options(system, choice_def),
+    do: Advancement.sub_choice_options(system, choice_def)
+
+  @doc """
   Returns the current preparation state for the given inventory type.
 
   Computes mode, cap, eligible pool, always-prepared items, and currently

--- a/apps/ex_ttrpg_dev/lib/characters/advancement.ex
+++ b/apps/ex_ttrpg_dev/lib/characters/advancement.ex
@@ -157,6 +157,62 @@ defmodule ExTTRPGDev.Characters.Advancement do
   defp validate_progression_value(nil), do: {:error, :value_required}
   defp validate_progression_value(_), do: {:error, :value_must_be_integer}
 
+  @doc """
+  Fetches the definition of a sub-choice declared by a concept.
+
+  See `ExTTRPGDev.Characters.fetch_choice_def!/3` for documentation.
+  """
+  def fetch_choice_def!(system, {type, id}, choice_id) do
+    get_in(system.concept_metadata, [{type, id}, "choices", choice_id]) ||
+      raise("unknown choice #{inspect(choice_id)} on #{type}(#{id})")
+  end
+
+  @doc """
+  Returns the currently valid selections for a concept sub-choice.
+
+  See `ExTTRPGDev.Characters.valid_sub_choices/4` for documentation.
+  """
+  def valid_sub_choices(system, {scope_type, scope_id} = scope, choice_def, decisions) do
+    choice_type = choice_def["type"]
+    raw_options = sub_choice_options(system, choice_def)
+
+    already_chosen =
+      decisions
+      |> Enum.filter(fn
+        %{scope: ^scope, choice: choice} ->
+          cd =
+            get_in(system.concept_metadata, [{scope_type, scope_id}, "choices", choice]) || %{}
+
+          cd["type"] == choice_type
+
+        _ ->
+          false
+      end)
+      |> MapSet.new(& &1.selection)
+
+    Enum.reject(raw_options, &MapSet.member?(already_chosen, &1))
+  end
+
+  @doc """
+  The raw option list for a sub-choice definition.
+
+  See `ExTTRPGDev.Characters.sub_choice_options/2` for documentation.
+  """
+  def sub_choice_options(system, choice_def) do
+    case choice_def["options"] do
+      options when is_list(options) ->
+        options
+
+      _ ->
+        choice_type = choice_def["type"]
+
+        system.concept_metadata
+        |> Enum.filter(fn {{t, _}, _} -> t == choice_type end)
+        |> Enum.map(fn {{_, id}, _} -> id end)
+        |> Enum.sort()
+    end
+  end
+
   defp consume_slot(pending_choice_slots, progression_id) do
     case Enum.split_while(pending_choice_slots, &(&1.progression_id != progression_id)) do
       {before_slots, [_ | after_slots]} -> before_slots ++ after_slots

--- a/apps/ttrpg_dev_cli/lib/cli/serializer.ex
+++ b/apps/ttrpg_dev_cli/lib/cli/serializer.ex
@@ -1,8 +1,10 @@
 defmodule ExTTRPGDev.CLI.Serializer do
   @moduledoc """
-  Converts domain objects (LoadedSystem, Character, etc.) into plain maps
-  ready for JSON encoding. Extracted from Server to keep that module within
-  code health thresholds.
+  Renders domain objects (LoadedSystem, Character, pending choices,
+  inventory) into the plain maps the JSON protocol responds with.
+
+  This module owns presentation only — option filtering and validation live
+  in the `ExTTRPGDev.Characters` library.
   """
 
   alias ExTTRPGDev.Characters
@@ -171,32 +173,6 @@ defmodule ExTTRPGDev.CLI.Serializer do
       )
     end)
     |> Enum.sort_by(& &1.id)
-  end
-
-  def fetch_choice_def!(system, {type, id}, choice_id) do
-    get_in(system.concept_metadata, [{type, id}, "choices", choice_id]) ||
-      raise("unknown choice #{inspect(choice_id)} on #{type}(#{id})")
-  end
-
-  def valid_sub_choices(system, {scope_type, scope_id} = scope, choice_def, decisions) do
-    choice_type = choice_def["type"]
-    raw_options = build_sub_choice_options(choice_def, choice_type, system)
-
-    already_chosen =
-      decisions
-      |> Enum.filter(fn
-        %{scope: ^scope, choice: choice} ->
-          cd =
-            get_in(system.concept_metadata, [{scope_type, scope_id}, "choices", choice]) || %{}
-
-          cd["type"] == choice_type
-
-        _ ->
-          false
-      end)
-      |> MapSet.new(& &1.selection)
-
-    Enum.reject(raw_options, &MapSet.member?(already_chosen, &1))
   end
 
   defp serialize_selected_concepts(
@@ -451,7 +427,7 @@ defmodule ExTTRPGDev.CLI.Serializer do
          system
        ) do
     choice_type = choice_def["type"]
-    raw_options = build_sub_choice_options(choice_def, choice_type, system)
+    raw_options = Characters.sub_choice_options(system, choice_def)
     excluded = MapSet.new(Map.get(already_chosen_by_type, choice_type, []))
     filtered = Enum.reject(raw_options, &MapSet.member?(excluded, &1))
     template = find_display_template(system, choice_type)
@@ -473,18 +449,5 @@ defmodule ExTTRPGDev.CLI.Serializer do
         options: rendered
       }
     ]
-  end
-
-  defp build_sub_choice_options(choice_def, choice_type, system) do
-    case choice_def["options"] do
-      options when is_list(options) ->
-        options
-
-      _ ->
-        system.concept_metadata
-        |> Enum.filter(fn {{t, _}, _} -> t == choice_type end)
-        |> Enum.map(fn {{_, id}, _} -> id end)
-        |> Enum.sort()
-    end
   end
 end

--- a/apps/ttrpg_dev_cli/lib/cli/server.ex
+++ b/apps/ttrpg_dev_cli/lib/cli/server.ex
@@ -47,6 +47,7 @@ defmodule ExTTRPGDev.CLI.Server do
   alias ExTTRPGDev.Characters
   alias ExTTRPGDev.Characters.{Character, InventoryItem}
   alias ExTTRPGDev.CLI.Serializer
+  alias ExTTRPGDev.CLI.Server.Errors
   alias ExTTRPGDev.RuleSystem.InventoryRules
   alias ExTTRPGDev.RuleSystems
 
@@ -62,7 +63,10 @@ defmodule ExTTRPGDev.CLI.Server do
   # success, so a mid-handler raise cannot leak partial mutations.
   @doc false
   def handle_command(msg, state) do
-    handle(msg, state)
+    case handle(msg, state) do
+      {:ok, data, new_state} -> {ok(data), new_state}
+      {:error, message} -> {error(message), state}
+    end
   rescue
     e -> {error(Exception.message(e)), state}
   end
@@ -111,13 +115,13 @@ defmodule ExTTRPGDev.CLI.Server do
         %{spec: spec, rolls: rolls, total: Enum.sum(rolls)}
       end)
 
-    {ok(%{results: results}), state}
+    {:ok, %{results: results}, state}
   end
 
   # --- Systems ---
 
   defp handle(%{"command" => "systems.list"}, state) do
-    {ok(%{systems: RuleSystems.list_systems()}), state}
+    {:ok, %{systems: RuleSystems.list_systems()}, state}
   end
 
   defp handle(%{"command" => "systems.show", "system" => slug} = cmd, state) do
@@ -139,7 +143,7 @@ defmodule ExTTRPGDev.CLI.Server do
           Serializer.serialize_system(system)
       end
 
-    {ok(data), state}
+    {:ok, data, state}
   end
 
   # --- Characters ---
@@ -168,7 +172,7 @@ defmodule ExTTRPGDev.CLI.Server do
         temp_id
       )
 
-    {ok(data), new_state}
+    {:ok, data, new_state}
   end
 
   # --- Character Build ---
@@ -187,7 +191,7 @@ defmodule ExTTRPGDev.CLI.Server do
     new_state = %{state | pending: pending, next_id: state.next_id + 1}
 
     building_choices = Serializer.serialize_building_choices(system)
-    {ok(%{temp_id: temp_id, building_choices: building_choices}), new_state}
+    {:ok, %{temp_id: temp_id, building_choices: building_choices}, new_state}
   end
 
   defp handle(
@@ -213,7 +217,7 @@ defmodule ExTTRPGDev.CLI.Server do
       )
 
     new_state = %{state | pending: Map.put(state.pending, temp_id, updated)}
-    {ok(%{sub_choices: sub_choices}), new_state}
+    {:ok, %{sub_choices: sub_choices}, new_state}
   end
 
   defp handle(
@@ -240,7 +244,7 @@ defmodule ExTTRPGDev.CLI.Server do
       Serializer.serialize_concept_sub_choices(scope_type, scope_id, updated.decisions, system)
 
     new_state = %{state | pending: Map.put(state.pending, temp_id, updated)}
-    {ok(%{sub_choices: sub_choices}), new_state}
+    {:ok, %{sub_choices: sub_choices}, new_state}
   end
 
   defp handle(%{"command" => "characters.build_finish", "temp_id" => temp_id} = msg, state) do
@@ -253,19 +257,14 @@ defmodule ExTTRPGDev.CLI.Server do
     new_state = %{state | pending: Map.delete(state.pending, temp_id)}
     data = character_with_choices_response(sys, updated, updated.metadata.slug, msg)
 
-    {ok(data), new_state}
+    {:ok, data, new_state}
   end
 
   defp handle(%{"command" => "characters.save", "temp_id" => temp_id}, state) do
-    case Map.get(state.pending, temp_id) do
-      nil ->
-        {error("no pending character with temp_id #{inspect(temp_id)}"), state}
-
-      character ->
-        Characters.save_character!(character)
-        new_state = %{state | pending: Map.delete(state.pending, temp_id)}
-        {ok(%{slug: character.metadata.slug}), new_state}
-    end
+    character = fetch_pending!(state, temp_id)
+    Characters.save_character!(character)
+    new_state = %{state | pending: Map.delete(state.pending, temp_id)}
+    {:ok, %{slug: character.metadata.slug}, new_state}
   end
 
   defp handle(%{"command" => "characters.list"} = cmd, state) do
@@ -285,7 +284,7 @@ defmodule ExTTRPGDev.CLI.Server do
         }
       end)
 
-    {ok(%{characters: characters}), state}
+    {:ok, %{characters: characters}, state}
   end
 
   defp handle(
@@ -309,10 +308,10 @@ defmodule ExTTRPGDev.CLI.Server do
           |> character_with_choices_response(updated, slug, msg)
           |> Map.merge(extras)
 
-        {ok(data), state}
+        {:ok, data, state}
 
       {:error, reason} ->
-        {error(format_award_error(reason)), state}
+        {:error, Errors.message(reason)}
     end
   end
 
@@ -323,10 +322,11 @@ defmodule ExTTRPGDev.CLI.Server do
     {_effects, resolved} = Characters.resolved_state(system, character)
     choices = Characters.pending_choices(system, character, resolved)
 
-    {ok(%{
+    {:ok,
+     %{
        pending_choices:
          Serializer.serialize_choices_list(choices, system, parse_display_mode(msg))
-     }), state}
+     }, state}
   end
 
   defp handle(
@@ -350,10 +350,10 @@ defmodule ExTTRPGDev.CLI.Server do
          ) do
       {:ok, updated} ->
         Characters.save_character!(updated, true)
-        {ok(character_with_choices_response(system, updated, slug, msg)), state}
+        {:ok, character_with_choices_response(system, updated, slug, msg), state}
 
       {:error, reason} ->
-        {error(format_resolve_error(reason)), state}
+        {:error, Errors.message(reason)}
     end
   end
 
@@ -370,13 +370,13 @@ defmodule ExTTRPGDev.CLI.Server do
       Serializer.serialize_character(system, updated, slug, parse_display_mode(msg))
       |> Map.put(:resolutions, Serializer.serialize_resolutions(resolutions, system))
 
-    {ok(data), state}
+    {:ok, data, state}
   end
 
   defp handle(%{"command" => "characters.delete", "character" => slug}, state) do
     case Characters.delete_character(slug) do
-      :ok -> {ok(%{deleted: slug}), state}
-      {:error, :not_found} -> {error("Character not found: #{slug}"), state}
+      :ok -> {:ok, %{deleted: slug}, state}
+      {:error, :not_found} -> {:error, "character not found: #{inspect(slug)}"}
     end
   end
 
@@ -384,7 +384,7 @@ defmodule ExTTRPGDev.CLI.Server do
     character = Characters.load_character!(slug)
     system = RuleSystems.load_system!(character.metadata.rule_system)
     data = Serializer.serialize_character(system, character, slug, parse_display_mode(msg))
-    {ok(data), state}
+    {:ok, data, state}
   end
 
   defp handle(
@@ -406,20 +406,21 @@ defmodule ExTTRPGDev.CLI.Server do
         meta -> meta["name"] || concept_id
       end
 
-    {ok(%{
+    {:ok,
+     %{
        concept_name: concept_name,
        dice: result.dice,
        rolls: result.rolls,
        bonus: result.bonus,
        total: result.total
-     }), state}
+     }, state}
   end
 
   # --- Inventory ---
 
   defp handle(%{"command" => "characters.inventory", "character" => slug}, state) do
     character = Characters.load_character!(slug)
-    {ok(%{inventory: Serializer.serialize_inventory(character.inventory)}), state}
+    {:ok, %{inventory: Serializer.serialize_inventory(character.inventory)}, state}
   end
 
   defp handle(
@@ -440,10 +441,10 @@ defmodule ExTTRPGDev.CLI.Server do
       {:ok, item} ->
         updated = %{character | inventory: character.inventory ++ [item]}
         Characters.save_character!(updated, true)
-        {ok(%{inventory: Serializer.serialize_inventory(updated.inventory)}), state}
+        {:ok, %{inventory: Serializer.serialize_inventory(updated.inventory)}, state}
 
       {:error, reason} ->
-        {error("cannot add item: #{inspect(reason)}"), state}
+        {:error, "cannot add item: " <> Errors.message(reason)}
     end
   end
 
@@ -469,10 +470,10 @@ defmodule ExTTRPGDev.CLI.Server do
         new_inventory = List.replace_at(character.inventory, index, updated_item)
         updated = %{character | inventory: new_inventory}
         Characters.save_character!(updated, true)
-        {ok(%{inventory: Serializer.serialize_inventory(updated.inventory)}), state}
+        {:ok, %{inventory: Serializer.serialize_inventory(updated.inventory)}, state}
 
       {:error, reason} ->
-        {error("cannot set field: #{inspect(reason)}"), state}
+        {:error, "cannot set field: " <> Errors.message(reason)}
     end
   end
 
@@ -501,7 +502,7 @@ defmodule ExTTRPGDev.CLI.Server do
 
     data = character_with_choices_response(system, updated, slug, msg)
 
-    {ok(data), state}
+    {:ok, data, state}
   end
 
   # --- Spell preparation ---
@@ -528,8 +529,8 @@ defmodule ExTTRPGDev.CLI.Server do
       end
 
     case result do
-      {:ok, data} -> {ok(data), state}
-      {:error, reason} -> {error(inspect(reason)), state}
+      {:ok, data} -> {:ok, data, state}
+      {:error, reason} -> {:error, Errors.message(reason)}
     end
   end
 
@@ -547,26 +548,26 @@ defmodule ExTTRPGDev.CLI.Server do
 
     case InventoryRules.type_for_activate_command(system.inventory_rules, verb) do
       nil ->
-        {error("unknown activate verb: #{inspect(verb)}"), state}
+        {:error, "unknown activate verb: #{inspect(verb)}"}
 
       {type_id, _config} ->
         case Characters.activate(system, character, type_id, item_ids) do
           {:ok, updated} ->
             Characters.save_character!(updated, true)
-            {ok(%{inventory: Serializer.serialize_inventory(updated.inventory)}), state}
+            {:ok, %{inventory: Serializer.serialize_inventory(updated.inventory)}, state}
 
           {:error, reason} ->
-            {error(format_activate_error(reason)), state}
+            {:error, Errors.message(reason)}
         end
     end
   end
 
-  defp handle(%{"command" => cmd}, state) do
-    {error("unknown command: #{inspect(cmd)}"), state}
+  defp handle(%{"command" => cmd}, _state) do
+    {:error, "unknown command: #{inspect(cmd)}"}
   end
 
-  defp handle(_, state) do
-    {error("request must have a \"command\" field"), state}
+  defp handle(_, _state) do
+    {:error, "request must have a \"command\" field"}
   end
 
   defp format_prep_response(%{
@@ -586,65 +587,11 @@ defmodule ExTTRPGDev.CLI.Server do
     if cap, do: Map.put(base, :cap, cap), else: base
   end
 
-  defp format_activate_error({:ineligible_items, ids}),
-    do: "ineligible items: #{Enum.join(ids, ", ")}"
-
-  defp format_activate_error({:exceeds_cap, count, cap}),
-    do: "cannot prepare more than #{cap} (given: #{count})"
-
-  defp format_activate_error({:mode_not_prepared, mode}),
-    do: "items of this type cannot be manually activated (mode: \"#{mode}\")"
-
-  defp format_activate_error(:no_preparation_class),
-    do: "no class with preparation_mode found for this character"
-
-  defp format_activate_error(:no_preparation_cap), do: "class has no preparation cap"
-  defp format_activate_error(reason), do: inspect(reason)
-
   defp validate_concept_selection!(selection, valid_options) do
     unless selection in valid_options do
       raise("#{inspect(selection)} is not available for this character and progression")
     end
   end
-
-  defp format_resolve_error({:unknown_progression, id}),
-    do: "unknown progression: #{inspect(id)}"
-
-  defp format_resolve_error({:no_pending_choice, id}),
-    do: "no pending choice for progression: #{inspect(id)}"
-
-  defp format_resolve_error({:invalid_selection, selection}),
-    do: "#{inspect(selection)} is not available for this character and progression"
-
-  defp format_resolve_error(:value_required), do: "value is required for this progression"
-  defp format_resolve_error(:value_must_be_integer), do: "value must be an integer"
-  defp format_resolve_error(:missing_effect_target), do: "progression has no effect_target"
-
-  defp format_resolve_error({:invalid_effect_target, target}),
-    do: "invalid effect target: #{inspect(target)}"
-
-  defp format_resolve_error({:inventory_error, reason}),
-    do: "failed to add to inventory: #{inspect(reason)}"
-
-  defp format_award_error({:unknown_award, id}), do: "unknown award: #{inspect(id)}"
-
-  defp format_award_error({:value_required, value_type}),
-    do:
-      "award #{inspect(value_type)} requires an explicit value; use: characters award <slug> #{value_type} <value>"
-
-  defp format_award_error(:value_must_be_integer), do: "value must be an integer for this award"
-  defp format_award_error(:max_level), do: "character is already at max level"
-
-  defp format_award_error(:no_level_thresholds),
-    do: "system does not define level XP thresholds"
-
-  defp format_award_error({:unsupported_value_type, value_type}),
-    do: "unsupported award value_type: #{inspect(value_type)}"
-
-  defp format_award_error(:missing_effect_target), do: "award has no effect_target"
-
-  defp format_award_error({:invalid_effect_target, target}),
-    do: "invalid effect target: #{inspect(target)}"
 
   defp fetch_pending!(state, temp_id) do
     Map.get(state.pending, temp_id) || raise("no pending character: #{inspect(temp_id)}")

--- a/apps/ttrpg_dev_cli/lib/cli/server.ex
+++ b/apps/ttrpg_dev_cli/lib/cli/server.ex
@@ -230,8 +230,8 @@ defmodule ExTTRPGDev.CLI.Server do
     character = fetch_pending!(state, temp_id)
     system = RuleSystems.load_system!(character.metadata.rule_system)
     scope = {scope_type, scope_id}
-    choice_def = Serializer.fetch_choice_def!(system, scope, choice_id)
-    valid = Serializer.valid_sub_choices(system, scope, choice_def, character.decisions)
+    choice_def = Characters.fetch_choice_def!(system, scope, choice_id)
+    valid = Characters.valid_sub_choices(system, scope, choice_def, character.decisions)
     validate_concept_selection!(selection, valid)
     decision = %{scope: scope, choice: choice_id, selection: selection}
     updated = %{character | decisions: character.decisions ++ [decision]}
@@ -491,8 +491,8 @@ defmodule ExTTRPGDev.CLI.Server do
     system = RuleSystems.load_system!(character.metadata.rule_system)
 
     scope = {scope_type, scope_id}
-    choice_def = Serializer.fetch_choice_def!(system, scope, choice_id)
-    valid = Serializer.valid_sub_choices(system, scope, choice_def, character.decisions)
+    choice_def = Characters.fetch_choice_def!(system, scope, choice_id)
+    valid = Characters.valid_sub_choices(system, scope, choice_def, character.decisions)
     validate_concept_selection!(selection, valid)
 
     decision = %{scope: scope, choice: choice_id, selection: selection}

--- a/apps/ttrpg_dev_cli/lib/cli/server.ex
+++ b/apps/ttrpg_dev_cli/lib/cli/server.ex
@@ -9,23 +9,60 @@ defmodule ExTTRPGDev.CLI.Server do
 
   ## Protocol
 
-  Each request is a single line of JSON:
+  Each request is a single line of JSON with a `command` field; each response
+  is a single line of JSON:
+
+      {"status": "ok", "data": {...}}
+      {"status": "error", "message": "..."}
+
+  Every request additionally accepts an optional `"display_mode"` field
+  (`"default"`, `"verbose"`, or `"succinct"`) controlling how concept labels
+  are rendered.
+
+  ### Dice
 
       {"command": "roll", "dice": "3d6"}
+      {"command": "roll", "dice": "3d6,1d20"}
+
+  ### Systems
+
       {"command": "systems.list"}
       {"command": "systems.show", "system": "dnd_5e_srd"}
       {"command": "systems.show", "system": "dnd_5e_srd", "concept_type": "skill"}
+      {"command": "systems.show", "system": "dnd_5e_srd", "concept_type": "skill", "concept_id": "acrobatics"}
+
+  ### Characters
+
       {"command": "characters.gen", "system": "dnd_5e_srd"}
       {"command": "characters.save", "temp_id": "1"}
       {"command": "characters.list"}
       {"command": "characters.list", "system": "dnd_5e_srd"}
       {"command": "characters.show", "character": "thorin-stoneback"}
+      {"command": "characters.delete", "character": "thorin-stoneback"}
       {"command": "characters.roll", "character": "thorin-stoneback", "type": "skill", "concept": "acrobatics"}
       {"command": "characters.award", "character": "thorin-stoneback", "award": "experience_points", "value": 300}
       {"command": "characters.award", "character": "thorin-stoneback", "award": "level_up"}
       {"command": "characters.choices", "character": "thorin-stoneback"}
       {"command": "characters.resolve_choice", "character": "thorin-stoneback", "progression": "hp_per_level", "value": 7, "selection": "rolled"}
+      {"command": "characters.resolve_choice", "character": "thorin-stoneback", "progression": "cantrips", "selection": "fire_bolt"}
       {"command": "characters.resolve_choice", "character": "thorin-stoneback", "scope_type": "feat", "scope_id": "ability_score_improvement", "choice": "asi_point_1", "selection": "strength"}
+      {"command": "characters.random_resolve", "character": "thorin-stoneback"}
+
+  ### Character builder
+
+  `build_start` generates an empty character and returns a `temp_id` plus the
+  root building choices (race, class, background, ...). `build_select` picks a
+  root concept and returns its pending sub-choices; `build_resolve_sub`
+  answers one sub-choice. `build_finish` derives starting inventory and
+  pending choice slots, saves the character, and releases the `temp_id`.
+
+      {"command": "characters.build_start", "system": "dnd_5e_srd", "name": "Thorin Stoneback"}
+      {"command": "characters.build_select", "temp_id": "1", "concept_type": "class", "concept_id": "cleric"}
+      {"command": "characters.build_resolve_sub", "temp_id": "1", "scope_type": "class", "scope_id": "cleric", "choice": "skill_proficiency_1", "selection": "history"}
+      {"command": "characters.build_finish", "temp_id": "1"}
+
+  ### Inventory and preparation
+
       {"command": "characters.inventory", "character": "thorin-stoneback"}
       {"command": "characters.inventory.add", "character": "thorin-stoneback", "type": "equipment", "id": "longsword"}
       {"command": "characters.inventory.add", "character": "thorin-stoneback", "type": "equipment", "id": "chain_mail", "fields": {"equipped": true}}
@@ -34,13 +71,8 @@ defmodule ExTTRPGDev.CLI.Server do
       {"command": "characters.activate", "character": "thorin-stoneback", "verb": "prepare", "items": ["bless", "cure_wounds"]}
       {"command": "characters.activate", "character": "thorin-stoneback", "verb": "equip", "items": [0]}
 
-  Each response is a single line of JSON:
-
-      {"status": "ok", "data": {...}}
-      {"status": "error", "message": "..."}
-
   Generated-but-unsaved characters are held in memory under a `temp_id` until
-  `characters.save` is called or the server exits.
+  `characters.save` / `characters.build_finish` is called or the server exits.
   """
 
   alias ExTTRPGDev.CLI.Server.Handlers

--- a/apps/ttrpg_dev_cli/lib/cli/server.ex
+++ b/apps/ttrpg_dev_cli/lib/cli/server.ex
@@ -43,15 +43,40 @@ defmodule ExTTRPGDev.CLI.Server do
   `characters.save` is called or the server exits.
   """
 
-  alias DiceLib.Basic, as: Dice
-  alias ExTTRPGDev.Characters
-  alias ExTTRPGDev.Characters.{Character, InventoryItem}
-  alias ExTTRPGDev.CLI.Serializer
-  alias ExTTRPGDev.CLI.Server.Errors
-  alias ExTTRPGDev.RuleSystem.InventoryRules
-  alias ExTTRPGDev.RuleSystems
+  alias ExTTRPGDev.CLI.Server.Handlers
 
-  @type state :: %{pending: %{String.t() => Character.t()}, next_id: non_neg_integer()}
+  @type state :: %{
+          pending: %{String.t() => ExTTRPGDev.Characters.Character.t()},
+          next_id: non_neg_integer()
+        }
+
+  # Command -> handler-module registry. Every implemented protocol command
+  # must appear here; a command absent from this map is answered with an
+  # "unknown command" error.
+  @handlers %{
+    "roll" => Handlers.Dice,
+    "systems.list" => Handlers.Systems,
+    "systems.show" => Handlers.Systems,
+    "characters.gen" => Handlers.Characters,
+    "characters.save" => Handlers.Characters,
+    "characters.list" => Handlers.Characters,
+    "characters.show" => Handlers.Characters,
+    "characters.delete" => Handlers.Characters,
+    "characters.roll" => Handlers.Characters,
+    "characters.award" => Handlers.Characters,
+    "characters.choices" => Handlers.Characters,
+    "characters.resolve_choice" => Handlers.Characters,
+    "characters.random_resolve" => Handlers.Characters,
+    "characters.build_start" => Handlers.Build,
+    "characters.build_select" => Handlers.Build,
+    "characters.build_resolve_sub" => Handlers.Build,
+    "characters.build_finish" => Handlers.Build,
+    "characters.inventory" => Handlers.Inventory,
+    "characters.inventory.add" => Handlers.Inventory,
+    "characters.inventory.set" => Handlers.Inventory,
+    "characters.spells" => Handlers.Inventory,
+    "characters.activate" => Handlers.Inventory
+  }
 
   def run do
     loop(%{pending: %{}, next_id: 1})
@@ -63,13 +88,22 @@ defmodule ExTTRPGDev.CLI.Server do
   # success, so a mid-handler raise cannot leak partial mutations.
   @doc false
   def handle_command(msg, state) do
-    case handle(msg, state) do
+    case route(msg, state) do
       {:ok, data, new_state} -> {ok(data), new_state}
       {:error, message} -> {error(message), state}
     end
   rescue
     e -> {error(Exception.message(e)), state}
   end
+
+  defp route(%{"command" => command} = msg, state) do
+    case Map.fetch(@handlers, command) do
+      {:ok, handler} -> handler.handle(msg, state)
+      :error -> {:error, "unknown command: #{inspect(command)}"}
+    end
+  end
+
+  defp route(_msg, _state), do: {:error, "request must have a \"command\" field"}
 
   defp loop(state) do
     case IO.gets("") do
@@ -97,527 +131,6 @@ defmodule ExTTRPGDev.CLI.Server do
       {:ok, cmd} -> handle_command(cmd, state)
       {:error, _} -> {error("invalid JSON"), state}
     end
-  end
-
-  # --- Roll ---
-
-  defp handle(%{"command" => "roll", "dice" => dice_str}, state) do
-    specs =
-      dice_str
-      |> String.split(",")
-      |> Enum.map(&String.trim/1)
-      |> Enum.reject(&(&1 == ""))
-
-    results =
-      specs
-      |> Dice.multi_roll!()
-      |> Enum.map(fn {spec, rolls} ->
-        %{spec: spec, rolls: rolls, total: Enum.sum(rolls)}
-      end)
-
-    {:ok, %{results: results}, state}
-  end
-
-  # --- Systems ---
-
-  defp handle(%{"command" => "systems.list"}, state) do
-    {:ok, %{systems: RuleSystems.list_systems()}, state}
-  end
-
-  defp handle(%{"command" => "systems.show", "system" => slug} = cmd, state) do
-    concept_type = Map.get(cmd, "concept_type")
-    concept_id = Map.get(cmd, "concept_id")
-
-    system = RuleSystems.load_system!(slug)
-
-    data =
-      cond do
-        concept_id != nil ->
-          meta = system.concept_metadata[{concept_type, concept_id}] || %{}
-          %{id: concept_id, concept_type: concept_type, fields: meta}
-
-        concept_type != nil ->
-          Serializer.serialize_concepts(system, concept_type)
-
-        true ->
-          Serializer.serialize_system(system)
-      end
-
-    {:ok, data, state}
-  end
-
-  # --- Characters ---
-
-  defp handle(%{"command" => "characters.gen", "system" => slug} = msg, state) do
-    system = RuleSystems.load_system!(slug)
-    decisions = Characters.random_decisions(system)
-    character = Character.gen_character!(system, decisions)
-    slots = Characters.compute_pending_choice_slots(system, character)
-
-    character =
-      Characters.auto_resolve_pending(system, %{character | pending_choice_slots: slots})
-
-    temp_id = Integer.to_string(state.next_id)
-
-    new_state = %{
-      state
-      | pending: Map.put(state.pending, temp_id, character),
-        next_id: state.next_id + 1
-    }
-
-    data =
-      Map.put(
-        Serializer.serialize_character(system, character, nil, parse_display_mode(msg)),
-        :temp_id,
-        temp_id
-      )
-
-    {:ok, data, new_state}
-  end
-
-  # --- Character Build ---
-
-  defp handle(
-         %{"command" => "characters.build_start", "system" => slug, "name" => name},
-         state
-       ) do
-    system = RuleSystems.load_system!(slug)
-    character = Character.gen_character!(system, [])
-
-    slug = Character.slugify(name)
-    character = %{character | name: name, metadata: %{character.metadata | slug: slug}}
-    temp_id = Integer.to_string(state.next_id)
-    pending = Map.put(state.pending, temp_id, character)
-    new_state = %{state | pending: pending, next_id: state.next_id + 1}
-
-    building_choices = Serializer.serialize_building_choices(system)
-    {:ok, %{temp_id: temp_id, building_choices: building_choices}, new_state}
-  end
-
-  defp handle(
-         %{
-           "command" => "characters.build_select",
-           "temp_id" => temp_id,
-           "concept_type" => concept_type,
-           "concept_id" => concept_id
-         },
-         state
-       ) do
-    character = fetch_pending!(state, temp_id)
-    system = RuleSystems.load_system!(character.metadata.rule_system)
-    decision = %{scope: nil, choice: concept_type, selection: concept_id}
-    updated = %{character | decisions: character.decisions ++ [decision]}
-
-    sub_choices =
-      Serializer.serialize_concept_sub_choices(
-        concept_type,
-        concept_id,
-        updated.decisions,
-        system
-      )
-
-    new_state = %{state | pending: Map.put(state.pending, temp_id, updated)}
-    {:ok, %{sub_choices: sub_choices}, new_state}
-  end
-
-  defp handle(
-         %{
-           "command" => "characters.build_resolve_sub",
-           "temp_id" => temp_id,
-           "scope_type" => scope_type,
-           "scope_id" => scope_id,
-           "choice" => choice_id,
-           "selection" => selection
-         },
-         state
-       ) do
-    character = fetch_pending!(state, temp_id)
-    system = RuleSystems.load_system!(character.metadata.rule_system)
-    scope = {scope_type, scope_id}
-    choice_def = Characters.fetch_choice_def!(system, scope, choice_id)
-    valid = Characters.valid_sub_choices(system, scope, choice_def, character.decisions)
-    validate_concept_selection!(selection, valid)
-    decision = %{scope: scope, choice: choice_id, selection: selection}
-    updated = %{character | decisions: character.decisions ++ [decision]}
-
-    sub_choices =
-      Serializer.serialize_concept_sub_choices(scope_type, scope_id, updated.decisions, system)
-
-    new_state = %{state | pending: Map.put(state.pending, temp_id, updated)}
-    {:ok, %{sub_choices: sub_choices}, new_state}
-  end
-
-  defp handle(%{"command" => "characters.build_finish", "temp_id" => temp_id} = msg, state) do
-    char = fetch_pending!(state, temp_id)
-    sys = RuleSystems.load_system!(char.metadata.rule_system)
-    inv = Character.inventory_from_decisions(char.decisions, sys)
-    slots = Characters.compute_pending_choice_slots(sys, %{char | inventory: inv})
-    updated = %{char | inventory: inv, pending_choice_slots: slots}
-    Characters.save_character!(updated)
-    new_state = %{state | pending: Map.delete(state.pending, temp_id)}
-    data = character_with_choices_response(sys, updated, updated.metadata.slug, msg)
-
-    {:ok, data, new_state}
-  end
-
-  defp handle(%{"command" => "characters.save", "temp_id" => temp_id}, state) do
-    character = fetch_pending!(state, temp_id)
-    Characters.save_character!(character)
-    new_state = %{state | pending: Map.delete(state.pending, temp_id)}
-    {:ok, %{slug: character.metadata.slug}, new_state}
-  end
-
-  defp handle(%{"command" => "characters.list"} = cmd, state) do
-    system_filter = Map.get(cmd, "system")
-
-    characters =
-      Characters.list_characters!()
-      |> Enum.map(&Characters.load_character!/1)
-      |> Enum.filter(fn c ->
-        system_filter == nil or c.metadata.rule_system == system_filter
-      end)
-      |> Enum.map(fn c ->
-        %{
-          slug: c.metadata.slug,
-          name: c.name,
-          rule_system: c.metadata.rule_system
-        }
-      end)
-
-    {:ok, %{characters: characters}, state}
-  end
-
-  defp handle(
-         %{"command" => "characters.award", "character" => slug, "award" => award_id} = msg,
-         state
-       ) do
-    character = Characters.load_character!(slug)
-    system = RuleSystems.load_system!(character.metadata.rule_system)
-    explicit_value = Map.get(msg, "value")
-
-    case Characters.apply_award(system, character, award_id, explicit_value) do
-      {:ok, updated, awarded_value} ->
-        Characters.save_character!(updated, true)
-
-        # The response reports :awarded_xp only when the award computed its
-        # own amount (e.g. "level_up") rather than receiving an explicit one.
-        extras = if explicit_value == nil, do: %{awarded_xp: awarded_value}, else: %{}
-
-        data =
-          system
-          |> character_with_choices_response(updated, slug, msg)
-          |> Map.merge(extras)
-
-        {:ok, data, state}
-
-      {:error, reason} ->
-        {:error, Errors.message(reason)}
-    end
-  end
-
-  defp handle(%{"command" => "characters.choices", "character" => slug} = msg, state) do
-    character = Characters.load_character!(slug)
-    system = RuleSystems.load_system!(character.metadata.rule_system)
-
-    {_effects, resolved} = Characters.resolved_state(system, character)
-    choices = Characters.pending_choices(system, character, resolved)
-
-    {:ok,
-     %{
-       pending_choices:
-         Serializer.serialize_choices_list(choices, system, parse_display_mode(msg))
-     }, state}
-  end
-
-  defp handle(
-         %{
-           "command" => "characters.resolve_choice",
-           "character" => slug,
-           "progression" => progression_id,
-           "selection" => selection
-         } = msg,
-         state
-       ) do
-    character = Characters.load_character!(slug)
-    system = RuleSystems.load_system!(character.metadata.rule_system)
-
-    case Characters.resolve_progression_choice(
-           system,
-           character,
-           progression_id,
-           selection,
-           Map.get(msg, "value")
-         ) do
-      {:ok, updated} ->
-        Characters.save_character!(updated, true)
-        {:ok, character_with_choices_response(system, updated, slug, msg), state}
-
-      {:error, reason} ->
-        {:error, Errors.message(reason)}
-    end
-  end
-
-  defp handle(%{"command" => "characters.random_resolve", "character" => slug} = msg, state) do
-    character = Characters.load_character!(slug)
-    system = RuleSystems.load_system!(character.metadata.rule_system)
-    slots = Characters.compute_pending_choice_slots(system, character)
-    character = %{character | pending_choice_slots: slots}
-
-    {updated, resolutions} = Characters.random_resolve_all(system, character)
-    Characters.save_character!(updated, true)
-
-    data =
-      Serializer.serialize_character(system, updated, slug, parse_display_mode(msg))
-      |> Map.put(:resolutions, Serializer.serialize_resolutions(resolutions, system))
-
-    {:ok, data, state}
-  end
-
-  defp handle(%{"command" => "characters.delete", "character" => slug}, state) do
-    case Characters.delete_character(slug) do
-      :ok -> {:ok, %{deleted: slug}, state}
-      {:error, :not_found} -> {:error, "character not found: #{inspect(slug)}"}
-    end
-  end
-
-  defp handle(%{"command" => "characters.show", "character" => slug} = msg, state) do
-    character = Characters.load_character!(slug)
-    system = RuleSystems.load_system!(character.metadata.rule_system)
-    data = Serializer.serialize_character(system, character, slug, parse_display_mode(msg))
-    {:ok, data, state}
-  end
-
-  defp handle(
-         %{
-           "command" => "characters.roll",
-           "character" => slug,
-           "type" => type_id,
-           "concept" => concept_id
-         },
-         state
-       ) do
-    character = Characters.load_character!(slug)
-    system = RuleSystems.load_system!(character.metadata.rule_system)
-    result = Characters.concept_roll!(system, character, type_id, concept_id)
-
-    concept_name =
-      case Map.get(system.concept_metadata, {type_id, concept_id}) do
-        nil -> concept_id
-        meta -> meta["name"] || concept_id
-      end
-
-    {:ok,
-     %{
-       concept_name: concept_name,
-       dice: result.dice,
-       rolls: result.rolls,
-       bonus: result.bonus,
-       total: result.total
-     }, state}
-  end
-
-  # --- Inventory ---
-
-  defp handle(%{"command" => "characters.inventory", "character" => slug}, state) do
-    character = Characters.load_character!(slug)
-    {:ok, %{inventory: Serializer.serialize_inventory(character.inventory)}, state}
-  end
-
-  defp handle(
-         %{
-           "command" => "characters.inventory.add",
-           "character" => slug,
-           "type" => type,
-           "id" => id
-         } =
-           cmd,
-         state
-       ) do
-    character = Characters.load_character!(slug)
-    system = RuleSystems.load_system!(character.metadata.rule_system)
-    custom_fields = Map.get(cmd, "fields", %{})
-
-    case InventoryItem.new(type, id, system.inventory_rules, custom_fields) do
-      {:ok, item} ->
-        updated = %{character | inventory: character.inventory ++ [item]}
-        Characters.save_character!(updated, true)
-        {:ok, %{inventory: Serializer.serialize_inventory(updated.inventory)}, state}
-
-      {:error, reason} ->
-        {:error, "cannot add item: " <> Errors.message(reason)}
-    end
-  end
-
-  defp handle(
-         %{
-           "command" => "characters.inventory.set",
-           "character" => slug,
-           "index" => index,
-           "field" => field,
-           "value" => value
-         },
-         state
-       ) do
-    character = Characters.load_character!(slug)
-    system = RuleSystems.load_system!(character.metadata.rule_system)
-
-    item =
-      Enum.at(character.inventory, index) ||
-        raise("no inventory item at index #{inspect(index)}")
-
-    case InventoryItem.set_field(item, field, value, system.inventory_rules) do
-      {:ok, updated_item} ->
-        new_inventory = List.replace_at(character.inventory, index, updated_item)
-        updated = %{character | inventory: new_inventory}
-        Characters.save_character!(updated, true)
-        {:ok, %{inventory: Serializer.serialize_inventory(updated.inventory)}, state}
-
-      {:error, reason} ->
-        {:error, "cannot set field: " <> Errors.message(reason)}
-    end
-  end
-
-  defp handle(
-         %{
-           "command" => "characters.resolve_choice",
-           "character" => slug,
-           "scope_type" => scope_type,
-           "scope_id" => scope_id,
-           "choice" => choice_id,
-           "selection" => selection
-         } = msg,
-         state
-       ) do
-    character = Characters.load_character!(slug)
-    system = RuleSystems.load_system!(character.metadata.rule_system)
-
-    scope = {scope_type, scope_id}
-    choice_def = Characters.fetch_choice_def!(system, scope, choice_id)
-    valid = Characters.valid_sub_choices(system, scope, choice_def, character.decisions)
-    validate_concept_selection!(selection, valid)
-
-    decision = %{scope: scope, choice: choice_id, selection: selection}
-    updated = %{character | decisions: character.decisions ++ [decision]}
-    Characters.save_character!(updated, true)
-
-    data = character_with_choices_response(system, updated, slug, msg)
-
-    {:ok, data, state}
-  end
-
-  # --- Spell preparation ---
-
-  defp handle(%{"command" => "characters.spells", "character" => slug}, state) do
-    character = Characters.load_character!(slug)
-    system = RuleSystems.load_system!(character.metadata.rule_system)
-
-    # Only the first preparation type is returned. Returning multiple types
-    # would require a protocol change on both this handler and the Rust
-    # PreparationStateResponse struct. dnd_5e_srd has one preparation type
-    # ("spell"), so this is sufficient for now.
-    result =
-      case InventoryRules.preparation_types(system.inventory_rules) do
-        [] ->
-          {:ok, %{preparation_mode: nil}}
-
-        [{type_id, _} | _] ->
-          case Characters.preparation_state(system, character, type_id) do
-            {:ok, %{mode: nil}} -> {:ok, %{preparation_mode: nil}}
-            {:ok, s} -> {:ok, format_prep_response(s)}
-            error -> error
-          end
-      end
-
-    case result do
-      {:ok, data} -> {:ok, data, state}
-      {:error, reason} -> {:error, Errors.message(reason)}
-    end
-  end
-
-  defp handle(
-         %{
-           "command" => "characters.activate",
-           "character" => slug,
-           "verb" => verb,
-           "items" => item_ids
-         },
-         state
-       ) do
-    character = Characters.load_character!(slug)
-    system = RuleSystems.load_system!(character.metadata.rule_system)
-
-    case InventoryRules.type_for_activate_command(system.inventory_rules, verb) do
-      nil ->
-        {:error, "unknown activate verb: #{inspect(verb)}"}
-
-      {type_id, _config} ->
-        case Characters.activate(system, character, type_id, item_ids) do
-          {:ok, updated} ->
-            Characters.save_character!(updated, true)
-            {:ok, %{inventory: Serializer.serialize_inventory(updated.inventory)}, state}
-
-          {:error, reason} ->
-            {:error, Errors.message(reason)}
-        end
-    end
-  end
-
-  defp handle(%{"command" => cmd}, _state) do
-    {:error, "unknown command: #{inspect(cmd)}"}
-  end
-
-  defp handle(_, _state) do
-    {:error, "request must have a \"command\" field"}
-  end
-
-  defp format_prep_response(%{
-         mode: mode,
-         cap: cap,
-         eligible: eligible,
-         always_prepared: always,
-         prepared: prepared
-       }) do
-    base = %{
-      preparation_mode: mode,
-      eligible_items: eligible,
-      prepared_items: prepared,
-      always_active: always
-    }
-
-    if cap, do: Map.put(base, :cap, cap), else: base
-  end
-
-  defp validate_concept_selection!(selection, valid_options) do
-    unless selection in valid_options do
-      raise("#{inspect(selection)} is not available for this character and progression")
-    end
-  end
-
-  defp fetch_pending!(state, temp_id) do
-    Map.get(state.pending, temp_id) || raise("no pending character: #{inspect(temp_id)}")
-  end
-
-  defp parse_display_mode(msg) do
-    case Map.get(msg, "display_mode", "default") do
-      "verbose" -> :verbose
-      "succinct" -> :succinct
-      _ -> :default
-    end
-  end
-
-  # --- Response helpers ---
-
-  # The standard response body for mutate-then-report handlers: the character
-  # serialized against a single DAG evaluation, plus its recomputed pending
-  # choices rendered in the request's display mode.
-  defp character_with_choices_response(system, character, slug, msg) do
-    {_effects, resolved} = Characters.resolved_state(system, character)
-    choices = Characters.pending_choices(system, character, resolved)
-    mode = parse_display_mode(msg)
-
-    system
-    |> Serializer.serialize_character(character, slug, mode, resolved)
-    |> Map.put(:pending_choices, Serializer.serialize_choices_list(choices, system, mode))
   end
 
   defp ok(data), do: %{status: "ok", data: data}

--- a/apps/ttrpg_dev_cli/lib/cli/server/common.ex
+++ b/apps/ttrpg_dev_cli/lib/cli/server/common.ex
@@ -1,0 +1,54 @@
+defmodule ExTTRPGDev.CLI.Server.Common do
+  @moduledoc """
+  Request and response helpers shared by the server's handler modules.
+  """
+
+  alias ExTTRPGDev.Characters
+  alias ExTTRPGDev.CLI.Serializer
+
+  @doc """
+  Parses the optional `display_mode` field of a request into the atom the
+  serializer's display templates understand. Unknown values fall back to
+  `:default`.
+  """
+  def parse_display_mode(msg) do
+    case Map.get(msg, "display_mode", "default") do
+      "verbose" -> :verbose
+      "succinct" -> :succinct
+      _ -> :default
+    end
+  end
+
+  @doc """
+  The standard response body for mutate-then-report handlers: the character
+  serialized against a single DAG evaluation, plus its recomputed pending
+  choices rendered in the request's display mode.
+  """
+  def character_with_choices_response(system, character, slug, msg) do
+    {_effects, resolved} = Characters.resolved_state(system, character)
+    choices = Characters.pending_choices(system, character, resolved)
+    mode = parse_display_mode(msg)
+
+    system
+    |> Serializer.serialize_character(character, slug, mode, resolved)
+    |> Map.put(:pending_choices, Serializer.serialize_choices_list(choices, system, mode))
+  end
+
+  @doc """
+  Fetches a generated-but-unsaved character held under `temp_id`, raising
+  (toward the dispatch rescue boundary) when none exists.
+  """
+  def fetch_pending!(state, temp_id) do
+    Map.get(state.pending, temp_id) || raise("no pending character: #{inspect(temp_id)}")
+  end
+
+  @doc """
+  Raises (toward the dispatch rescue boundary) unless `selection` is one of
+  `valid_options`.
+  """
+  def validate_concept_selection!(selection, valid_options) do
+    unless selection in valid_options do
+      raise("#{inspect(selection)} is not available for this character and progression")
+    end
+  end
+end

--- a/apps/ttrpg_dev_cli/lib/cli/server/errors.ex
+++ b/apps/ttrpg_dev_cli/lib/cli/server/errors.ex
@@ -1,0 +1,84 @@
+defmodule ExTTRPGDev.CLI.Server.Errors do
+  @moduledoc """
+  The single formatting boundary between library error reasons and protocol
+  error messages.
+
+  Every domain `{:error, reason}` a handler surfaces must be rendered here so
+  the same condition always produces the same message and raw Elixir terms
+  never reach the frontend. New library error reasons should get a clause
+  here rather than fall through to the inspected-term fallback.
+  """
+
+  # --- awards ---
+
+  def message({:unknown_award, id}), do: "unknown award: #{inspect(id)}"
+
+  def message({:value_required, value_type}),
+    do:
+      "award #{inspect(value_type)} requires an explicit value; use: characters award <slug> #{value_type} <value>"
+
+  def message({:unsupported_value_type, value_type}),
+    do: "unsupported award value_type: #{inspect(value_type)}"
+
+  def message(:max_level), do: "character is already at max level"
+  def message(:no_level_thresholds), do: "system does not define level XP thresholds"
+
+  # --- progression choices ---
+
+  def message({:unknown_progression, id}), do: "unknown progression: #{inspect(id)}"
+
+  def message({:no_pending_choice, id}),
+    do: "no pending choice for progression: #{inspect(id)}"
+
+  def message({:invalid_selection, selection}),
+    do: "#{inspect(selection)} is not available for this character and progression"
+
+  def message(:value_required), do: "value is required for this progression"
+  def message(:value_must_be_integer), do: "value must be an integer"
+  def message(:missing_effect_target), do: "no effect_target configured"
+
+  def message({:invalid_effect_target, target}),
+    do: "invalid effect target: #{inspect(target)}"
+
+  def message({:inventory_error, reason}),
+    do: "failed to add to inventory: " <> message(reason)
+
+  # --- preparation / activation ---
+
+  def message({:ineligible_items, ids}), do: "ineligible items: #{Enum.join(ids, ", ")}"
+
+  def message({:exceeds_cap, count, cap}),
+    do: "cannot prepare more than #{cap} (given: #{count})"
+
+  def message({:mode_not_prepared, mode}),
+    do: "items of this type cannot be manually activated (mode: \"#{mode}\")"
+
+  def message(:no_preparation_class),
+    do: "no class with preparation_mode found for this character"
+
+  def message(:no_preparation_cap), do: "class has no preparation cap"
+
+  def message({:unknown_inventory_type, type_id}),
+    do: "unknown inventory type: #{inspect(type_id)}"
+
+  def message({:not_a_preparation_type, type_id}),
+    do: "inventory type #{inspect(type_id)} does not support preparation"
+
+  # --- inventory items ---
+
+  def message({:not_inventoriable, concept_type}),
+    do: "concepts of type #{inspect(concept_type)} cannot be added to inventory"
+
+  def message({:unknown_field, name}), do: "unknown inventory field: #{inspect(name)}"
+  def message({:invalid_type, expected}), do: "value must be of type #{expected}"
+
+  def message({:invalid_enum_value, value, allowed}),
+    do: "#{inspect(value)} is not one of: #{Enum.join(allowed, ", ")}"
+
+  def message({:below_minimum, value, min}), do: "#{value} is below the minimum of #{min}"
+  def message({:above_maximum, value, max}), do: "#{value} is above the maximum of #{max}"
+
+  # Defensive fallback for reasons not yet given a clause; should stay
+  # unreachable for every reason the library documents.
+  def message(reason), do: inspect(reason)
+end

--- a/apps/ttrpg_dev_cli/lib/cli/server/handlers/build.ex
+++ b/apps/ttrpg_dev_cli/lib/cli/server/handlers/build.ex
@@ -1,0 +1,99 @@
+defmodule ExTTRPGDev.CLI.Server.Handlers.Build do
+  @moduledoc """
+  Handles the `characters.build_*` commands: the interactive character
+  builder flow. A character under construction is held in server state under
+  a `temp_id` until `build_finish` (or `characters.save`) persists it.
+  """
+
+  alias ExTTRPGDev.Characters
+  alias ExTTRPGDev.Characters.Character
+  alias ExTTRPGDev.CLI.Serializer
+  alias ExTTRPGDev.CLI.Server.Common
+  alias ExTTRPGDev.RuleSystems
+
+  def handle(
+        %{"command" => "characters.build_start", "system" => slug, "name" => name},
+        state
+      ) do
+    system = RuleSystems.load_system!(slug)
+    character = Character.gen_character!(system, [])
+
+    slug = Character.slugify(name)
+    character = %{character | name: name, metadata: %{character.metadata | slug: slug}}
+    temp_id = Integer.to_string(state.next_id)
+    pending = Map.put(state.pending, temp_id, character)
+    new_state = %{state | pending: pending, next_id: state.next_id + 1}
+
+    building_choices = Serializer.serialize_building_choices(system)
+    {:ok, %{temp_id: temp_id, building_choices: building_choices}, new_state}
+  end
+
+  def handle(
+        %{
+          "command" => "characters.build_select",
+          "temp_id" => temp_id,
+          "concept_type" => concept_type,
+          "concept_id" => concept_id
+        },
+        state
+      ) do
+    character = Common.fetch_pending!(state, temp_id)
+    system = RuleSystems.load_system!(character.metadata.rule_system)
+    decision = %{scope: nil, choice: concept_type, selection: concept_id}
+    updated = %{character | decisions: character.decisions ++ [decision]}
+
+    sub_choices =
+      Serializer.serialize_concept_sub_choices(
+        concept_type,
+        concept_id,
+        updated.decisions,
+        system
+      )
+
+    new_state = %{state | pending: Map.put(state.pending, temp_id, updated)}
+    {:ok, %{sub_choices: sub_choices}, new_state}
+  end
+
+  def handle(
+        %{
+          "command" => "characters.build_resolve_sub",
+          "temp_id" => temp_id,
+          "scope_type" => scope_type,
+          "scope_id" => scope_id,
+          "choice" => choice_id,
+          "selection" => selection
+        },
+        state
+      ) do
+    character = Common.fetch_pending!(state, temp_id)
+    system = RuleSystems.load_system!(character.metadata.rule_system)
+    scope = {scope_type, scope_id}
+    choice_def = Characters.fetch_choice_def!(system, scope, choice_id)
+    valid = Characters.valid_sub_choices(system, scope, choice_def, character.decisions)
+    Common.validate_concept_selection!(selection, valid)
+    decision = %{scope: scope, choice: choice_id, selection: selection}
+    updated = %{character | decisions: character.decisions ++ [decision]}
+
+    sub_choices =
+      Serializer.serialize_concept_sub_choices(scope_type, scope_id, updated.decisions, system)
+
+    new_state = %{state | pending: Map.put(state.pending, temp_id, updated)}
+    {:ok, %{sub_choices: sub_choices}, new_state}
+  end
+
+  def handle(%{"command" => "characters.build_finish", "temp_id" => temp_id} = msg, state) do
+    char = Common.fetch_pending!(state, temp_id)
+    sys = RuleSystems.load_system!(char.metadata.rule_system)
+    inv = Character.inventory_from_decisions(char.decisions, sys)
+    slots = Characters.compute_pending_choice_slots(sys, %{char | inventory: inv})
+    updated = %{char | inventory: inv, pending_choice_slots: slots}
+    Characters.save_character!(updated)
+    new_state = %{state | pending: Map.delete(state.pending, temp_id)}
+    data = Common.character_with_choices_response(sys, updated, updated.metadata.slug, msg)
+
+    {:ok, data, new_state}
+  end
+
+  def handle(%{"command" => cmd}, _state),
+    do: {:error, "invalid arguments for command: #{inspect(cmd)}"}
+end

--- a/apps/ttrpg_dev_cli/lib/cli/server/handlers/characters.ex
+++ b/apps/ttrpg_dev_cli/lib/cli/server/handlers/characters.ex
@@ -1,0 +1,230 @@
+defmodule ExTTRPGDev.CLI.Server.Handlers.Characters do
+  @moduledoc """
+  Handles the `characters.*` lifecycle commands: generation, persistence,
+  display, rolls, awards, and choice resolution.
+
+  The character-builder flow lives in `Handlers.Build`; inventory and
+  preparation commands live in `Handlers.Inventory`.
+  """
+
+  alias ExTTRPGDev.Characters
+  alias ExTTRPGDev.Characters.Character
+  alias ExTTRPGDev.CLI.Serializer
+  alias ExTTRPGDev.CLI.Server.Common
+  alias ExTTRPGDev.CLI.Server.Errors
+  alias ExTTRPGDev.RuleSystems
+
+  def handle(%{"command" => "characters.gen", "system" => slug} = msg, state) do
+    system = RuleSystems.load_system!(slug)
+    decisions = Characters.random_decisions(system)
+    character = Character.gen_character!(system, decisions)
+    slots = Characters.compute_pending_choice_slots(system, character)
+
+    character =
+      Characters.auto_resolve_pending(system, %{character | pending_choice_slots: slots})
+
+    temp_id = Integer.to_string(state.next_id)
+
+    new_state = %{
+      state
+      | pending: Map.put(state.pending, temp_id, character),
+        next_id: state.next_id + 1
+    }
+
+    data =
+      Map.put(
+        Serializer.serialize_character(system, character, nil, Common.parse_display_mode(msg)),
+        :temp_id,
+        temp_id
+      )
+
+    {:ok, data, new_state}
+  end
+
+  def handle(%{"command" => "characters.save", "temp_id" => temp_id}, state) do
+    character = Common.fetch_pending!(state, temp_id)
+    Characters.save_character!(character)
+    new_state = %{state | pending: Map.delete(state.pending, temp_id)}
+    {:ok, %{slug: character.metadata.slug}, new_state}
+  end
+
+  def handle(%{"command" => "characters.list"} = cmd, state) do
+    system_filter = Map.get(cmd, "system")
+
+    characters =
+      Characters.list_characters!()
+      |> Enum.map(&Characters.load_character!/1)
+      |> Enum.filter(fn c ->
+        system_filter == nil or c.metadata.rule_system == system_filter
+      end)
+      |> Enum.map(fn c ->
+        %{
+          slug: c.metadata.slug,
+          name: c.name,
+          rule_system: c.metadata.rule_system
+        }
+      end)
+
+    {:ok, %{characters: characters}, state}
+  end
+
+  def handle(
+        %{"command" => "characters.award", "character" => slug, "award" => award_id} = msg,
+        state
+      ) do
+    character = Characters.load_character!(slug)
+    system = RuleSystems.load_system!(character.metadata.rule_system)
+    explicit_value = Map.get(msg, "value")
+
+    case Characters.apply_award(system, character, award_id, explicit_value) do
+      {:ok, updated, awarded_value} ->
+        Characters.save_character!(updated, true)
+
+        # The response reports :awarded_xp only when the award computed its
+        # own amount (e.g. "level_up") rather than receiving an explicit one.
+        extras = if explicit_value == nil, do: %{awarded_xp: awarded_value}, else: %{}
+
+        data =
+          system
+          |> Common.character_with_choices_response(updated, slug, msg)
+          |> Map.merge(extras)
+
+        {:ok, data, state}
+
+      {:error, reason} ->
+        {:error, Errors.message(reason)}
+    end
+  end
+
+  def handle(%{"command" => "characters.choices", "character" => slug} = msg, state) do
+    character = Characters.load_character!(slug)
+    system = RuleSystems.load_system!(character.metadata.rule_system)
+
+    {_effects, resolved} = Characters.resolved_state(system, character)
+    choices = Characters.pending_choices(system, character, resolved)
+
+    {:ok,
+     %{
+       pending_choices:
+         Serializer.serialize_choices_list(choices, system, Common.parse_display_mode(msg))
+     }, state}
+  end
+
+  def handle(
+        %{
+          "command" => "characters.resolve_choice",
+          "character" => slug,
+          "progression" => progression_id,
+          "selection" => selection
+        } = msg,
+        state
+      ) do
+    character = Characters.load_character!(slug)
+    system = RuleSystems.load_system!(character.metadata.rule_system)
+
+    case Characters.resolve_progression_choice(
+           system,
+           character,
+           progression_id,
+           selection,
+           Map.get(msg, "value")
+         ) do
+      {:ok, updated} ->
+        Characters.save_character!(updated, true)
+        {:ok, Common.character_with_choices_response(system, updated, slug, msg), state}
+
+      {:error, reason} ->
+        {:error, Errors.message(reason)}
+    end
+  end
+
+  def handle(
+        %{
+          "command" => "characters.resolve_choice",
+          "character" => slug,
+          "scope_type" => scope_type,
+          "scope_id" => scope_id,
+          "choice" => choice_id,
+          "selection" => selection
+        } = msg,
+        state
+      ) do
+    character = Characters.load_character!(slug)
+    system = RuleSystems.load_system!(character.metadata.rule_system)
+
+    scope = {scope_type, scope_id}
+    choice_def = Characters.fetch_choice_def!(system, scope, choice_id)
+    valid = Characters.valid_sub_choices(system, scope, choice_def, character.decisions)
+    Common.validate_concept_selection!(selection, valid)
+
+    decision = %{scope: scope, choice: choice_id, selection: selection}
+    updated = %{character | decisions: character.decisions ++ [decision]}
+    Characters.save_character!(updated, true)
+
+    data = Common.character_with_choices_response(system, updated, slug, msg)
+
+    {:ok, data, state}
+  end
+
+  def handle(%{"command" => "characters.random_resolve", "character" => slug} = msg, state) do
+    character = Characters.load_character!(slug)
+    system = RuleSystems.load_system!(character.metadata.rule_system)
+    slots = Characters.compute_pending_choice_slots(system, character)
+    character = %{character | pending_choice_slots: slots}
+
+    {updated, resolutions} = Characters.random_resolve_all(system, character)
+    Characters.save_character!(updated, true)
+
+    data =
+      Serializer.serialize_character(system, updated, slug, Common.parse_display_mode(msg))
+      |> Map.put(:resolutions, Serializer.serialize_resolutions(resolutions, system))
+
+    {:ok, data, state}
+  end
+
+  def handle(%{"command" => "characters.delete", "character" => slug}, state) do
+    case Characters.delete_character(slug) do
+      :ok -> {:ok, %{deleted: slug}, state}
+      {:error, :not_found} -> {:error, "character not found: #{inspect(slug)}"}
+    end
+  end
+
+  def handle(%{"command" => "characters.show", "character" => slug} = msg, state) do
+    character = Characters.load_character!(slug)
+    system = RuleSystems.load_system!(character.metadata.rule_system)
+    data = Serializer.serialize_character(system, character, slug, Common.parse_display_mode(msg))
+    {:ok, data, state}
+  end
+
+  def handle(
+        %{
+          "command" => "characters.roll",
+          "character" => slug,
+          "type" => type_id,
+          "concept" => concept_id
+        },
+        state
+      ) do
+    character = Characters.load_character!(slug)
+    system = RuleSystems.load_system!(character.metadata.rule_system)
+    result = Characters.concept_roll!(system, character, type_id, concept_id)
+
+    concept_name =
+      case Map.get(system.concept_metadata, {type_id, concept_id}) do
+        nil -> concept_id
+        meta -> meta["name"] || concept_id
+      end
+
+    {:ok,
+     %{
+       concept_name: concept_name,
+       dice: result.dice,
+       rolls: result.rolls,
+       bonus: result.bonus,
+       total: result.total
+     }, state}
+  end
+
+  def handle(%{"command" => cmd}, _state),
+    do: {:error, "invalid arguments for command: #{inspect(cmd)}"}
+end

--- a/apps/ttrpg_dev_cli/lib/cli/server/handlers/dice.ex
+++ b/apps/ttrpg_dev_cli/lib/cli/server/handlers/dice.ex
@@ -1,0 +1,27 @@
+defmodule ExTTRPGDev.CLI.Server.Handlers.Dice do
+  @moduledoc """
+  Handles the `roll` command: free-form dice rolling.
+  """
+
+  alias DiceLib.Basic, as: Dice
+
+  def handle(%{"command" => "roll", "dice" => dice_str}, state) do
+    specs =
+      dice_str
+      |> String.split(",")
+      |> Enum.map(&String.trim/1)
+      |> Enum.reject(&(&1 == ""))
+
+    results =
+      specs
+      |> Dice.multi_roll!()
+      |> Enum.map(fn {spec, rolls} ->
+        %{spec: spec, rolls: rolls, total: Enum.sum(rolls)}
+      end)
+
+    {:ok, %{results: results}, state}
+  end
+
+  def handle(%{"command" => cmd}, _state),
+    do: {:error, "invalid arguments for command: #{inspect(cmd)}"}
+end

--- a/apps/ttrpg_dev_cli/lib/cli/server/handlers/inventory.ex
+++ b/apps/ttrpg_dev_cli/lib/cli/server/handlers/inventory.ex
@@ -1,0 +1,148 @@
+defmodule ExTTRPGDev.CLI.Server.Handlers.Inventory do
+  @moduledoc """
+  Handles the `characters.inventory*`, `characters.spells`, and
+  `characters.activate` commands: typed inventory management and
+  preparation/activation state.
+  """
+
+  alias ExTTRPGDev.Characters
+  alias ExTTRPGDev.Characters.InventoryItem
+  alias ExTTRPGDev.CLI.Serializer
+  alias ExTTRPGDev.CLI.Server.Errors
+  alias ExTTRPGDev.RuleSystem.InventoryRules
+  alias ExTTRPGDev.RuleSystems
+
+  def handle(%{"command" => "characters.inventory", "character" => slug}, state) do
+    character = Characters.load_character!(slug)
+    {:ok, %{inventory: Serializer.serialize_inventory(character.inventory)}, state}
+  end
+
+  def handle(
+        %{
+          "command" => "characters.inventory.add",
+          "character" => slug,
+          "type" => type,
+          "id" => id
+        } =
+          cmd,
+        state
+      ) do
+    character = Characters.load_character!(slug)
+    system = RuleSystems.load_system!(character.metadata.rule_system)
+    custom_fields = Map.get(cmd, "fields", %{})
+
+    case InventoryItem.new(type, id, system.inventory_rules, custom_fields) do
+      {:ok, item} ->
+        updated = %{character | inventory: character.inventory ++ [item]}
+        Characters.save_character!(updated, true)
+        {:ok, %{inventory: Serializer.serialize_inventory(updated.inventory)}, state}
+
+      {:error, reason} ->
+        {:error, "cannot add item: " <> Errors.message(reason)}
+    end
+  end
+
+  def handle(
+        %{
+          "command" => "characters.inventory.set",
+          "character" => slug,
+          "index" => index,
+          "field" => field,
+          "value" => value
+        },
+        state
+      ) do
+    character = Characters.load_character!(slug)
+    system = RuleSystems.load_system!(character.metadata.rule_system)
+
+    item =
+      Enum.at(character.inventory, index) ||
+        raise("no inventory item at index #{inspect(index)}")
+
+    case InventoryItem.set_field(item, field, value, system.inventory_rules) do
+      {:ok, updated_item} ->
+        new_inventory = List.replace_at(character.inventory, index, updated_item)
+        updated = %{character | inventory: new_inventory}
+        Characters.save_character!(updated, true)
+        {:ok, %{inventory: Serializer.serialize_inventory(updated.inventory)}, state}
+
+      {:error, reason} ->
+        {:error, "cannot set field: " <> Errors.message(reason)}
+    end
+  end
+
+  def handle(%{"command" => "characters.spells", "character" => slug}, state) do
+    character = Characters.load_character!(slug)
+    system = RuleSystems.load_system!(character.metadata.rule_system)
+
+    # Only the first preparation type is returned. Returning multiple types
+    # would require a protocol change on both this handler and the Rust
+    # PreparationStateResponse struct. dnd_5e_srd has one preparation type
+    # ("spell"), so this is sufficient for now.
+    result =
+      case InventoryRules.preparation_types(system.inventory_rules) do
+        [] ->
+          {:ok, %{preparation_mode: nil}}
+
+        [{type_id, _} | _] ->
+          case Characters.preparation_state(system, character, type_id) do
+            {:ok, %{mode: nil}} -> {:ok, %{preparation_mode: nil}}
+            {:ok, s} -> {:ok, format_prep_response(s)}
+            error -> error
+          end
+      end
+
+    case result do
+      {:ok, data} -> {:ok, data, state}
+      {:error, reason} -> {:error, Errors.message(reason)}
+    end
+  end
+
+  def handle(
+        %{
+          "command" => "characters.activate",
+          "character" => slug,
+          "verb" => verb,
+          "items" => item_ids
+        },
+        state
+      ) do
+    character = Characters.load_character!(slug)
+    system = RuleSystems.load_system!(character.metadata.rule_system)
+
+    case InventoryRules.type_for_activate_command(system.inventory_rules, verb) do
+      nil ->
+        {:error, "unknown activate verb: #{inspect(verb)}"}
+
+      {type_id, _config} ->
+        case Characters.activate(system, character, type_id, item_ids) do
+          {:ok, updated} ->
+            Characters.save_character!(updated, true)
+            {:ok, %{inventory: Serializer.serialize_inventory(updated.inventory)}, state}
+
+          {:error, reason} ->
+            {:error, Errors.message(reason)}
+        end
+    end
+  end
+
+  def handle(%{"command" => cmd}, _state),
+    do: {:error, "invalid arguments for command: #{inspect(cmd)}"}
+
+  defp format_prep_response(%{
+         mode: mode,
+         cap: cap,
+         eligible: eligible,
+         always_prepared: always,
+         prepared: prepared
+       }) do
+    base = %{
+      preparation_mode: mode,
+      eligible_items: eligible,
+      prepared_items: prepared,
+      always_active: always
+    }
+
+    if cap, do: Map.put(base, :cap, cap), else: base
+  end
+end

--- a/apps/ttrpg_dev_cli/lib/cli/server/handlers/systems.ex
+++ b/apps/ttrpg_dev_cli/lib/cli/server/handlers/systems.ex
@@ -1,0 +1,37 @@
+defmodule ExTTRPGDev.CLI.Server.Handlers.Systems do
+  @moduledoc """
+  Handles the `systems.*` commands: listing and inspecting rule systems.
+  """
+
+  alias ExTTRPGDev.CLI.Serializer
+  alias ExTTRPGDev.RuleSystems
+
+  def handle(%{"command" => "systems.list"}, state) do
+    {:ok, %{systems: RuleSystems.list_systems()}, state}
+  end
+
+  def handle(%{"command" => "systems.show", "system" => slug} = cmd, state) do
+    concept_type = Map.get(cmd, "concept_type")
+    concept_id = Map.get(cmd, "concept_id")
+
+    system = RuleSystems.load_system!(slug)
+
+    data =
+      cond do
+        concept_id != nil ->
+          meta = system.concept_metadata[{concept_type, concept_id}] || %{}
+          %{id: concept_id, concept_type: concept_type, fields: meta}
+
+        concept_type != nil ->
+          Serializer.serialize_concepts(system, concept_type)
+
+        true ->
+          Serializer.serialize_system(system)
+      end
+
+    {:ok, data, state}
+  end
+
+  def handle(%{"command" => cmd}, _state),
+    do: {:error, "invalid arguments for command: #{inspect(cmd)}"}
+end


### PR DESCRIPTION
Closes #132.

## What

Four commits, mapping to the issue's four fixes:

1. **Sub-choice validation into the library** — `fetch_choice_def!` and `valid_sub_choices` move from `Serializer` to `Characters.Advancement` (with `Characters` wrappers), following #131's pattern. Their shared option-derivation helper becomes public `Characters.sub_choice_options/2` and the Serializer's rendering path now uses it, so the options shown and the options validated can no longer drift. The Serializer moduledoc now states its actual responsibility instead of apologizing for its existence.

2. **One error contract, one formatter** — handlers return `{:ok, data, state} | {:error, message}`; `handle_command` builds protocol envelopes in exactly one place. All domain `{:error, reason}` terms render through the new `Server.Errors.message/1` (awards, progression choices, preparation/activation, inventory-field validation). The `characters.spells`, `inventory.add`, and `inventory.set` handlers no longer leak `inspect(reason)` terms to the Rust frontend. Same-condition-same-message unifications: `:value_must_be_integer`, `:missing_effect_target`, and the two missing-pending-character messages (`characters.save` now uses `fetch_pending!`).

3. **Per-group handler modules + registry** — `server.ex` drops from 660 lines / 26 clauses to 138 lines of dispatch: loop, rescue boundary, envelopes, and an explicit command → module registry (`Handlers.Dice`, `.Systems`, `.Characters`, `.Build`, `.Inventory`; shared helpers in `Server.Common`). Both `resolve_choice` forms now sit adjacent in `Handlers.Characters` (the scoped one previously lived under the Inventory section, 227 lines from its sibling). Known commands with malformed arguments now get "invalid arguments for command: ..." instead of falling through to a misleading "unknown command".

4. **Complete protocol docs** — all 22 registry commands documented with examples (previously six were missing: `build_start/select/resolve_sub/finish`, `random_resolve`, `delete`), grouped to mirror the handler modules, with a builder-flow walkthrough and the protocol-wide `display_mode` field noted. Verified programmatically that every registry command appears in the moduledoc.

## Notes

- No test asserted on any error-message text, so the standardization required no test updates; all 382 tests pass unchanged.
- `Errors.message/1` keeps a defensive `inspect` fallback clause for reasons not yet given a message — every documented library reason has an explicit clause.
- credo and dialyzer clean; codescene passes on each commit.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added new advancement sub-choice logic to handle concept-based choices and exclusion pools.</li>
<li>Implemented `fetch_choice_def!`, `valid_sub_choices`, and `sub_choice_options` in `ExTTRPGDev.Characters.Advancement`.</li>
<li>Updated CLI server handlers to support new advancement choice validation and retrieval.</li>
<li>Refactored CLI server handlers to use the new advancement logic for character progression.</li>
</ul></div>