### PR TITLE
refactor: introduce Node, Effect, and Decision structs

### DIFF
--- a/apps/ex_ttrpg_dev/lib/characters.ex
+++ b/apps/ex_ttrpg_dev/lib/characters.ex
@@ -10,6 +10,7 @@ defmodule ExTTRPGDev.Characters do
   alias ExTTRPGDev.Globals
   alias ExTTRPGDev.RuleSystem.Evaluator
   alias ExTTRPGDev.RuleSystem.Expression
+  alias ExTTRPGDev.RuleSystem.Effect
   alias ExTTRPGDev.RuleSystem.InventoryRules
   alias ExTTRPGDev.RuleSystem.Node
   alias ExTTRPGDev.RuleSystem.Vocabulary
@@ -512,8 +513,8 @@ defmodule ExTTRPGDev.Characters do
 
     system.effects
     |> Enum.filter(fn
-      %{source: {type, id}} -> MapSet.member?(active, {type, id})
-      %{source: {type, id, _}} -> MapSet.member?(active, {type, id})
+      %Effect{source: {type, id}} -> MapSet.member?(active, {type, id})
+      %Effect{source: {type, id, _}} -> MapSet.member?(active, {type, id})
       _ -> false
     end)
     |> Kernel.++(decision_effects)
@@ -759,7 +760,7 @@ defmodule ExTTRPGDev.Characters do
     [node_key | _] = Expression.extract_refs(entry.effect_target)
 
     decision = next_progression_decision(character.decisions, entry.id, method)
-    effect = %{target: node_key, value: value}
+    effect = %Effect{target: node_key, value: value}
 
     updated = %{
       character
@@ -1160,7 +1161,7 @@ defmodule ExTTRPGDev.Characters do
             "contributes_value" => value,
             "type" => target_type
           } ->
-            [%{source: {type, id}, target: {target_type, selected, field}, value: value}]
+            [%Effect{source: {type, id}, target: {target_type, selected, field}, value: value}]
 
           _ ->
             []
@@ -1175,10 +1176,10 @@ defmodule ExTTRPGDev.Characters do
     Enum.flat_map(inventory, fn %InventoryItem{} = item ->
       system.effects
       |> Enum.filter(fn
-        %{source: {type, id}} -> type == item.concept_type and id == item.concept_id
+        %Effect{source: {type, id}} -> type == item.concept_type and id == item.concept_id
         _ -> false
       end)
-      |> Enum.map(&Map.put(&1, :item_fields, item.fields))
+      |> Enum.map(fn %Effect{} = effect -> %{effect | item_fields: item.fields} end)
     end)
   end
 
@@ -1286,7 +1287,7 @@ defmodule ExTTRPGDev.Characters do
 
     level_effects =
       if xp_target && xp_for_level > 0 do
-        [%{target: xp_target, value: xp_for_level} | non_xp_effects]
+        [%Effect{target: xp_target, value: xp_for_level} | non_xp_effects]
       else
         non_xp_effects
       end

--- a/apps/ex_ttrpg_dev/lib/characters.ex
+++ b/apps/ex_ttrpg_dev/lib/characters.ex
@@ -11,6 +11,7 @@ defmodule ExTTRPGDev.Characters do
   alias ExTTRPGDev.RuleSystem.Evaluator
   alias ExTTRPGDev.RuleSystem.Expression
   alias ExTTRPGDev.RuleSystem.InventoryRules
+  alias ExTTRPGDev.RuleSystem.Node
   alias ExTTRPGDev.RuleSystem.Vocabulary
   alias ExTTRPGDev.RuleSystems.LoadedSystem
 
@@ -1252,7 +1253,7 @@ defmodule ExTTRPGDev.Characters do
   defp level_xp_thresholds(%LoadedSystem{} = system) do
     with level_node when not is_nil(level_node) <- system.module.level_node,
          [{type_id, concept_id, field_name} | _] <- Expression.extract_refs(level_node),
-         %{type: :mapping, steps: steps} when not is_nil(steps) <-
+         %Node{type: :mapping, steps: steps} when not is_nil(steps) <-
            Map.get(system.nodes, {type_id, concept_id, field_name}) do
       Map.new(steps, fn [threshold, level] -> {level, threshold} end)
     else
@@ -1263,7 +1264,7 @@ defmodule ExTTRPGDev.Characters do
   defp xp_effect_target(%LoadedSystem{} = system) do
     with level_node when not is_nil(level_node) <- system.module.level_node,
          [{type_id, concept_id, field_name} | _] <- Expression.extract_refs(level_node),
-         %{type: :mapping, input: input} when not is_nil(input) <-
+         %Node{type: :mapping, input: input} when not is_nil(input) <-
            Map.get(system.nodes, {type_id, concept_id, field_name}),
          [node_key | _] <- Expression.extract_refs(input) do
       node_key

--- a/apps/ex_ttrpg_dev/lib/characters.ex
+++ b/apps/ex_ttrpg_dev/lib/characters.ex
@@ -5,6 +5,7 @@ defmodule ExTTRPGDev.Characters do
   alias DiceLib.Basic, as: Dice
   alias ExTTRPGDev.Characters.Advancement
   alias ExTTRPGDev.Characters.Character
+  alias ExTTRPGDev.Characters.Decision
   alias ExTTRPGDev.Characters.Metadata
   alias ExTTRPGDev.Characters.InventoryItem
   alias ExTTRPGDev.Globals
@@ -150,7 +151,7 @@ defmodule ExTTRPGDev.Characters do
     |> Enum.flat_map(fn %{concept_type: type_id} ->
       root_ids = root_concept_ids(system.concept_metadata, type_id)
       selected_id = Enum.random(root_ids)
-      decision = %{scope: nil, choice: type_id, selection: selected_id}
+      decision = %Decision{scope: nil, choice: type_id, selection: selected_id}
       [decision | random_sub_decisions(system.concept_metadata, {type_id, selected_id})]
     end)
   end
@@ -709,7 +710,7 @@ defmodule ExTTRPGDev.Characters do
   defp resolve_sub_choice(system, entry, character) do
     selection = Enum.random(entry.options)
 
-    decision = %{
+    decision = %Decision{
       scope: {entry.scope_type, entry.scope_id},
       choice: entry.id,
       selection: selection
@@ -1117,7 +1118,7 @@ defmodule ExTTRPGDev.Characters do
   def next_progression_decision(decisions, progression_id, selection) do
     n = count_progression_decisions(decisions, progression_id) + 1
 
-    %{
+    %Decision{
       scope: Vocabulary.progression_scope(progression_id),
       choice: Vocabulary.progression_choice_id(n),
       selection: selection
@@ -1126,7 +1127,7 @@ defmodule ExTTRPGDev.Characters do
 
   defp count_progression_decisions(decisions, progression_id) do
     Enum.count(decisions, fn
-      %{scope: {@progression_type, ^progression_id}} -> true
+      %Decision{scope: {@progression_type, ^progression_id}} -> true
       _ -> false
     end)
   end
@@ -1148,7 +1149,7 @@ defmodule ExTTRPGDev.Characters do
 
   defp effects_from_decisions(decisions, concept_metadata) do
     Enum.flat_map(decisions, fn
-      %{scope: {type, id}, choice: choice_id, selection: selected} ->
+      %Decision{scope: {type, id}, choice: choice_id, selection: selected} ->
         choice_def =
           concept_metadata
           |> Map.get({type, id}, %{})
@@ -1213,7 +1214,7 @@ defmodule ExTTRPGDev.Characters do
     |> Enum.flat_map(fn {choice_id, choice_def} ->
       sub_type = choice_def["type"]
       selected = Enum.random(choice_def["options"])
-      decision = %{scope: {type_id, concept_id}, choice: choice_id, selection: selected}
+      decision = %Decision{scope: {type_id, concept_id}, choice: choice_id, selection: selected}
 
       if Map.get(choice_def, "grants_to") == "inventory" do
         [decision]
@@ -1308,7 +1309,7 @@ defmodule ExTTRPGDev.Characters do
 
   defp find_prep_concept(decisions, concept_metadata, type_id, mode_field) do
     Enum.find_value(decisions, fn
-      %{scope: nil, choice: ^type_id, selection: concept_id} ->
+      %Decision{scope: nil, choice: ^type_id, selection: concept_id} ->
         meta = Map.get(concept_metadata, {type_id, concept_id}, %{})
         if Map.has_key?(meta, mode_field), do: {type_id, concept_id}, else: nil
 
@@ -1471,7 +1472,7 @@ defmodule ExTTRPGDev.Characters do
 
     Enum.any?(choices, fn %{concept_type: class_type} ->
       Enum.any?(character.decisions, fn
-        %{scope: nil, choice: ^class_type, selection: class_id} ->
+        %Decision{scope: nil, choice: ^class_type, selection: class_id} ->
           meta = Map.get(system.concept_metadata, {class_type, class_id}, %{})
           meta[field] == expected_value
 

--- a/apps/ex_ttrpg_dev/lib/characters/advancement.ex
+++ b/apps/ex_ttrpg_dev/lib/characters/advancement.ex
@@ -10,6 +10,7 @@ defmodule ExTTRPGDev.Characters.Advancement do
 
   alias ExTTRPGDev.Characters
   alias ExTTRPGDev.Characters.Character
+  alias ExTTRPGDev.Characters.Decision
   alias ExTTRPGDev.RuleSystem.Effect
   alias ExTTRPGDev.RuleSystem.Expression
   alias ExTTRPGDev.RuleSystem.Vocabulary
@@ -183,7 +184,7 @@ defmodule ExTTRPGDev.Characters.Advancement do
     already_chosen =
       decisions
       |> Enum.filter(fn
-        %{scope: ^scope, choice: choice} ->
+        %Decision{scope: ^scope, choice: choice} ->
           cd =
             get_in(system.concept_metadata, [{scope_type, scope_id}, "choices", choice]) || %{}
 

--- a/apps/ex_ttrpg_dev/lib/characters/advancement.ex
+++ b/apps/ex_ttrpg_dev/lib/characters/advancement.ex
@@ -10,6 +10,7 @@ defmodule ExTTRPGDev.Characters.Advancement do
 
   alias ExTTRPGDev.Characters
   alias ExTTRPGDev.Characters.Character
+  alias ExTTRPGDev.RuleSystem.Effect
   alias ExTTRPGDev.RuleSystem.Expression
   alias ExTTRPGDev.RuleSystem.Vocabulary
   alias ExTTRPGDev.RuleSystems.LoadedSystem
@@ -28,7 +29,10 @@ defmodule ExTTRPGDev.Characters.Advancement do
     with {:ok, meta} <- fetch_award_meta(system, award_id),
          {:ok, awarded} <- award_value(system, character, meta, value),
          {:ok, target} <- fetch_effect_target(meta) do
-      updated = %{character | effects: character.effects ++ [%{target: target, value: awarded}]}
+      updated = %{
+        character
+        | effects: character.effects ++ [%Effect{target: target, value: awarded}]
+      }
 
       updated = %{
         updated
@@ -147,7 +151,7 @@ defmodule ExTTRPGDev.Characters.Advancement do
       {:ok,
        %{
          character
-         | effects: character.effects ++ [%{target: target, value: value}],
+         | effects: character.effects ++ [%Effect{target: target, value: value}],
            decisions: character.decisions ++ [decision]
        }}
     end

--- a/apps/ex_ttrpg_dev/lib/characters/character.ex
+++ b/apps/ex_ttrpg_dev/lib/characters/character.ex
@@ -1,7 +1,7 @@
 defmodule ExTTRPGDev.Characters.Character do
   alias __MODULE__
   alias DiceLib.Basic, as: Dice
-  alias ExTTRPGDev.Characters.{InventoryItem, Metadata}
+  alias ExTTRPGDev.Characters.{Decision, InventoryItem, Metadata}
   alias ExTTRPGDev.RuleSystem.Effect
   alias ExTTRPGDev.RuleSystem.InventoryRules
   alias ExTTRPGDev.RuleSystem.Node
@@ -13,7 +13,7 @@ defmodule ExTTRPGDev.Characters.Character do
   - `generated_values` — map of `{type_id, concept_id, field_name} => integer` for leaf nodes
   - `effects` — list of `%Effect{target: {type_id, concept_id, field_name}, value: integer}`
     for currently active items, feats, statuses etc. (defaults to [])
-  - `decisions` — list of `%{scope: nil | {type_id, concept_id}, choice: string, selection: string}`
+  - `decisions` — list of `%Decision{scope: nil | {type_id, concept_id}, choice: string, selection: string}`
     recording each concept selection made during character creation (defaults to [])
   - `inventory` — list of `%InventoryItem{}` representing items the character is carrying
     (defaults to [])
@@ -90,7 +90,7 @@ defmodule ExTTRPGDev.Characters.Character do
             "fields" => item.fields
           }
         end),
-      "decisions" => Enum.map(char.decisions, &serialize_decision/1),
+      "decisions" => Enum.map(char.decisions, &Decision.to_json_map/1),
       "pending_choice_slots" =>
         Enum.map(char.pending_choice_slots, fn %{
                                                  progression_id: pid,
@@ -133,7 +133,7 @@ defmodule ExTTRPGDev.Characters.Character do
         }
       end)
 
-    decisions = Enum.map(map["decisions"] || [], &deserialize_decision/1)
+    decisions = Enum.map(map["decisions"] || [], &Decision.from_json_map/1)
 
     pending_choice_slots =
       Enum.map(map["pending_choice_slots"] || [], fn slot ->
@@ -158,23 +158,6 @@ defmodule ExTTRPGDev.Characters.Character do
     }
   end
 
-  defp serialize_decision(%{scope: nil, choice: choice, selection: selection}) do
-    %{"scope" => nil, "choice" => choice, "selection" => selection}
-  end
-
-  defp serialize_decision(%{scope: {type, id}, choice: choice, selection: selection}) do
-    %{"scope" => "#{type}:#{id}", "choice" => choice, "selection" => selection}
-  end
-
-  defp deserialize_decision(%{"scope" => nil, "choice" => choice, "selection" => selection}) do
-    %{scope: nil, choice: choice, selection: selection}
-  end
-
-  defp deserialize_decision(%{"scope" => scope_str, "choice" => choice, "selection" => selection}) do
-    [type, id] = String.split(scope_str, ":", parts: 2)
-    %{scope: {type, id}, choice: choice, selection: selection}
-  end
-
   def inventory_from_decisions(decisions, system) do
     static = starting_equipment_items(decisions, system)
     chosen = equipment_choice_items(decisions, system)
@@ -194,7 +177,7 @@ defmodule ExTTRPGDev.Characters.Character do
 
   defp equipment_choice_items(decisions, system) do
     Enum.flat_map(decisions, fn
-      %{scope: {type, id}, choice: choice_id, selection: selected} ->
+      %Decision{scope: {type, id}, choice: choice_id, selection: selected} ->
         choice_def =
           system.concept_metadata
           |> Map.get({type, id}, %{})

--- a/apps/ex_ttrpg_dev/lib/characters/character.ex
+++ b/apps/ex_ttrpg_dev/lib/characters/character.ex
@@ -3,6 +3,7 @@ defmodule ExTTRPGDev.Characters.Character do
   alias DiceLib.Basic, as: Dice
   alias ExTTRPGDev.Characters.{InventoryItem, Metadata}
   alias ExTTRPGDev.RuleSystem.InventoryRules
+  alias ExTTRPGDev.RuleSystem.Node
   alias ExTTRPGDev.RuleSystems.LoadedSystem
 
   @moduledoc """
@@ -222,7 +223,7 @@ defmodule ExTTRPGDev.Characters.Character do
 
   defp item_from_spec(_, _), do: []
 
-  defp roll_generated_value(%{method: method_id}, rolling_methods) do
+  defp roll_generated_value(%Node{method: method_id}, rolling_methods) do
     method = resolve_rolling_method(method_id, rolling_methods)
     rolls = Dice.roll(method.dice)
 

--- a/apps/ex_ttrpg_dev/lib/characters/character.ex
+++ b/apps/ex_ttrpg_dev/lib/characters/character.ex
@@ -2,6 +2,7 @@ defmodule ExTTRPGDev.Characters.Character do
   alias __MODULE__
   alias DiceLib.Basic, as: Dice
   alias ExTTRPGDev.Characters.{InventoryItem, Metadata}
+  alias ExTTRPGDev.RuleSystem.Effect
   alias ExTTRPGDev.RuleSystem.InventoryRules
   alias ExTTRPGDev.RuleSystem.Node
   alias ExTTRPGDev.RuleSystems.LoadedSystem
@@ -10,7 +11,7 @@ defmodule ExTTRPGDev.Characters.Character do
   Definition of an individual character.
 
   - `generated_values` — map of `{type_id, concept_id, field_name} => integer` for leaf nodes
-  - `effects` — list of `%{target: {type_id, concept_id, field_name}, value: integer}`
+  - `effects` — list of `%Effect{target: {type_id, concept_id, field_name}, value: integer}`
     for currently active items, feats, statuses etc. (defaults to [])
   - `decisions` — list of `%{scope: nil | {type_id, concept_id}, choice: string, selection: string}`
     recording each concept selection made during character creation (defaults to [])
@@ -78,7 +79,7 @@ defmodule ExTTRPGDev.Characters.Character do
           {"#{type}:#{id}:#{field}", value}
         end),
       "effects" =>
-        Enum.map(char.effects, fn %{target: {type, id, field}, value: v} ->
+        Enum.map(char.effects, fn %Effect{target: {type, id, field}, value: v} ->
           %{"target" => "#{type}:#{id}:#{field}", "value" => v}
         end),
       "inventory" =>
@@ -120,7 +121,7 @@ defmodule ExTTRPGDev.Characters.Character do
     effects =
       Enum.map(map["effects"] || [], fn %{"target" => target, "value" => v} ->
         [type, id, field] = String.split(target, ":", parts: 3)
-        %{target: {type, id, field}, value: v}
+        %Effect{target: {type, id, field}, value: v}
       end)
 
     inventory =

--- a/apps/ex_ttrpg_dev/lib/characters/decision.ex
+++ b/apps/ex_ttrpg_dev/lib/characters/decision.ex
@@ -1,0 +1,50 @@
+defmodule ExTTRPGDev.Characters.Decision do
+  @moduledoc """
+  A single choice recorded on a character.
+
+  - `:scope` — `nil` for root character-building choices (race, class, ...);
+    `{type_id, concept_id}` for a choice declared by that concept, including
+    progression scopes (`{"character_progression", progression_id}`).
+  - `:choice` — the choice identifier within the scope: a concept type ID at
+    root scope, a declared choice key or canonical progression choice ID
+    (`"choice_N"`) otherwise.
+  - `:selection` — the selected concept ID, or a value-method label for value
+    progressions (e.g. `"rolled"`).
+  """
+
+  @type scope :: nil | {String.t(), String.t()}
+
+  @type t :: %__MODULE__{
+          scope: scope(),
+          choice: String.t(),
+          selection: String.t()
+        }
+
+  defstruct [:scope, :choice, :selection]
+
+  @doc "Builds a decision."
+  def new(scope, choice, selection),
+    do: %__MODULE__{scope: scope, choice: choice, selection: selection}
+
+  @doc """
+  Encodes a decision for character JSON. A `nil` scope stays `null`; a
+  `{type, id}` scope is encoded as `"type:id"`.
+  """
+  def to_json_map(%__MODULE__{scope: nil, choice: choice, selection: selection}) do
+    %{"scope" => nil, "choice" => choice, "selection" => selection}
+  end
+
+  def to_json_map(%__MODULE__{scope: {type, id}, choice: choice, selection: selection}) do
+    %{"scope" => "#{type}:#{id}", "choice" => choice, "selection" => selection}
+  end
+
+  @doc "Decodes a decision from its character-JSON map form."
+  def from_json_map(%{"scope" => nil, "choice" => choice, "selection" => selection}) do
+    %__MODULE__{scope: nil, choice: choice, selection: selection}
+  end
+
+  def from_json_map(%{"scope" => scope_str, "choice" => choice, "selection" => selection}) do
+    [type, id] = String.split(scope_str, ":", parts: 2)
+    %__MODULE__{scope: {type, id}, choice: choice, selection: selection}
+  end
+end

--- a/apps/ex_ttrpg_dev/lib/rule_system/effect.ex
+++ b/apps/ex_ttrpg_dev/lib/rule_system/effect.ex
@@ -1,0 +1,31 @@
+defmodule ExTTRPGDev.RuleSystem.Effect do
+  @moduledoc """
+  A contribution to an accumulator node.
+
+  - `:source` — `{type_id, concept_id}` of the concept that declared the
+    effect, or `nil` for effects the character carries directly (awards,
+    rolled values). Only effects whose source concept is active apply.
+  - `:target` — `{type_id, concept_id, field_name}` node key the value
+    contributes to.
+  - `:value` — a number, or a formula string evaluated against resolved
+    nodes (with `item.<field>` placeholders substituted from
+    `:item_fields`).
+  - `:when` — optional condition formula; the effect applies only when it
+    evaluates truthy.
+  - `:item_fields` — field map of the inventory item that granted this
+    effect (`%{}` otherwise); the substitution source for `item.<field>`
+    references in `:value` and `:when`.
+  """
+
+  @type node_key :: {String.t(), String.t(), String.t()}
+
+  @type t :: %__MODULE__{
+          source: {String.t(), String.t()} | node_key() | nil,
+          target: node_key(),
+          value: number() | String.t(),
+          when: String.t() | nil,
+          item_fields: %{optional(String.t()) => term()}
+        }
+
+  defstruct [:source, :target, :value, :when, item_fields: %{}]
+end

--- a/apps/ex_ttrpg_dev/lib/rule_system/evaluator.ex
+++ b/apps/ex_ttrpg_dev/lib/rule_system/evaluator.ex
@@ -7,7 +7,7 @@ defmodule ExTTRPGDev.RuleSystem.Evaluator do
   and produces a fully-resolved map of all node values.
   """
 
-  alias ExTTRPGDev.RuleSystem.{Expression, Graph}
+  alias ExTTRPGDev.RuleSystem.{Expression, Graph, Node}
 
   @doc """
   Evaluates all nodes in the DAG in topological order.
@@ -48,16 +48,16 @@ defmodule ExTTRPGDev.RuleSystem.Evaluator do
 
   defp evaluate_node(node_key, nodes, resolved, effects) do
     case Map.fetch(nodes, node_key) do
-      {:ok, %{type: :generated}} ->
+      {:ok, %Node{type: :generated}} ->
         fetch_generated(resolved, node_key)
 
-      {:ok, %{type: :formula, formula: formula}} ->
+      {:ok, %Node{type: :formula, formula: formula}} ->
         Expression.evaluate(formula, resolved)
 
-      {:ok, %{type: :accumulator, base: base_formula}} ->
+      {:ok, %Node{type: :accumulator, base: base_formula}} ->
         evaluate_accumulator(base_formula, node_key, resolved, effects)
 
-      {:ok, %{type: :mapping, input: input_formula, steps: steps}} ->
+      {:ok, %Node{type: :mapping, input: input_formula, steps: steps}} ->
         evaluate_mapping(input_formula, steps, resolved)
 
       :error ->

--- a/apps/ex_ttrpg_dev/lib/rule_system/evaluator.ex
+++ b/apps/ex_ttrpg_dev/lib/rule_system/evaluator.ex
@@ -7,14 +7,14 @@ defmodule ExTTRPGDev.RuleSystem.Evaluator do
   and produces a fully-resolved map of all node values.
   """
 
-  alias ExTTRPGDev.RuleSystem.{Expression, Graph, Node}
+  alias ExTTRPGDev.RuleSystem.{Effect, Expression, Graph, Node}
 
   @doc """
   Evaluates all nodes in the DAG in topological order.
 
   - `system` — output of `Graph.build/1`
   - `generated_values` — map of `{type_id, concept_id, field_name} => number` for generated nodes
-  - `effects` — list of `%{target: {type_id, concept_id, field_name}, value: number}`
+  - `effects` — list of `%Effect{target: {type_id, concept_id, field_name}, value: number}`
 
   Returns `{:ok, resolved_map}` or `{:error, reason}`.
 
@@ -68,15 +68,16 @@ defmodule ExTTRPGDev.RuleSystem.Evaluator do
   defp evaluate_accumulator(base_formula, node_key, resolved, effects) do
     with {:ok, base_value} <- Expression.evaluate(base_formula, resolved) do
       effects
-      |> Enum.filter(fn %{target: target} -> target == node_key end)
+      |> Enum.filter(fn %Effect{target: target} -> target == node_key end)
       |> Enum.reduce_while({:ok, base_value}, &apply_effect(&1, &2, resolved))
     end
   end
 
-  defp apply_effect(effect, {:ok, acc}, resolved) do
-    condition = Map.get(effect, :when)
-    item_fields = Map.get(effect, :item_fields, %{})
-
+  defp apply_effect(
+         %Effect{when: condition, item_fields: item_fields} = effect,
+         {:ok, acc},
+         resolved
+       ) do
     with {:ok, true} <- evaluate_condition(condition, resolved, item_fields),
          {:ok, n} <- resolve_effect_value(effect.value, resolved, item_fields) do
       {:cont, {:ok, acc + n}}

--- a/apps/ex_ttrpg_dev/lib/rule_system/graph.ex
+++ b/apps/ex_ttrpg_dev/lib/rule_system/graph.ex
@@ -6,6 +6,7 @@ defmodule ExTTRPGDev.RuleSystem.Graph do
   Directed edges flow from dependency to dependent (e.g. `base_score` → `total_score`).
   """
 
+  alias ExTTRPGDev.RuleSystem.Effect
   alias ExTTRPGDev.RuleSystem.Expression
   alias ExTTRPGDev.RuleSystem.Node
 
@@ -173,7 +174,7 @@ defmodule ExTTRPGDev.RuleSystem.Graph do
     end)
   end
 
-  defp add_single_effect_edge(graph, nodes, %{target: target_key} = effect)
+  defp add_single_effect_edge(graph, nodes, %Effect{target: target_key} = effect)
        when is_tuple(target_key) do
     if Map.has_key?(nodes, target_key) do
       add_formula_effect_edge(graph, nodes, target_key, effect.value)
@@ -185,7 +186,7 @@ defmodule ExTTRPGDev.RuleSystem.Graph do
   # The Loader only emits tuple targets (unparseable ones are warned about
   # and dropped at load time), so anything else reaching this point is a
   # caller bug worth rejecting rather than silently ignoring.
-  defp add_single_effect_edge(_graph, _nodes, %{target: target}) do
+  defp add_single_effect_edge(_graph, _nodes, %Effect{target: target}) do
     {:error, {:invalid_effect_target, target}}
   end
 

--- a/apps/ex_ttrpg_dev/lib/rule_system/graph.ex
+++ b/apps/ex_ttrpg_dev/lib/rule_system/graph.ex
@@ -7,6 +7,7 @@ defmodule ExTTRPGDev.RuleSystem.Graph do
   """
 
   alias ExTTRPGDev.RuleSystem.Expression
+  alias ExTTRPGDev.RuleSystem.Node
 
   @doc """
   Builds a validated DAG from loader output.
@@ -158,9 +159,9 @@ defmodule ExTTRPGDev.RuleSystem.Graph do
     end
   end
 
-  defp node_formula(%{type: :formula, formula: formula}), do: formula
-  defp node_formula(%{type: :accumulator, base: base}), do: base
-  defp node_formula(%{type: :mapping, input: input}), do: input
+  defp node_formula(%Node{type: :formula, formula: formula}), do: formula
+  defp node_formula(%Node{type: :accumulator, base: base}), do: base
+  defp node_formula(%Node{type: :mapping, input: input}), do: input
   defp node_formula(_), do: nil
 
   defp add_effect_edges(graph, nodes, effects) do

--- a/apps/ex_ttrpg_dev/lib/rule_system/loader.ex
+++ b/apps/ex_ttrpg_dev/lib/rule_system/loader.ex
@@ -7,7 +7,7 @@ defmodule ExTTRPGDev.RuleSystem.Loader do
   ```
   %{
     module: %RuleModule{},
-    nodes: %{{type_id, concept_id, field_name} => node_map},
+    nodes: %{{type_id, concept_id, field_name} => %Node{}},
     rolling_methods: %{method_id => method_map},
     concept_metadata: %{{type_id, concept_id} => metadata_map},
     effects: [effect_map]
@@ -129,7 +129,7 @@ defmodule ExTTRPGDev.RuleSystem.Loader do
 
   require Logger
 
-  alias ExTTRPGDev.RuleSystem.{Expression, InventoryRules, RuleModule, Vocabulary}
+  alias ExTTRPGDev.RuleSystem.{Expression, InventoryRules, Node, RuleModule, Vocabulary}
 
   @module_file "module.toml"
   @character_building_file "character_building.toml"
@@ -328,19 +328,19 @@ defmodule ExTTRPGDev.RuleSystem.Loader do
   end
 
   defp parse_node(%{"type" => "generated"} = map) do
-    %{type: :generated, method: Map.get(map, "method")}
+    %Node{type: :generated, method: Map.get(map, "method")}
   end
 
   defp parse_node(%{"type" => "accumulator"} = map) do
-    %{type: :accumulator, base: Map.get(map, "base")}
+    %Node{type: :accumulator, base: Map.get(map, "base")}
   end
 
   defp parse_node(%{"type" => "mapping"} = map) do
-    %{type: :mapping, input: Map.get(map, "input"), steps: Map.get(map, "steps")}
+    %Node{type: :mapping, input: Map.get(map, "input"), steps: Map.get(map, "steps")}
   end
 
   defp parse_node(%{"formula" => formula}) do
-    %{type: :formula, formula: formula}
+    %Node{type: :formula, formula: formula}
   end
 
   # Unrecognized node definition (e.g. a typo'd "type" value with no
@@ -356,7 +356,7 @@ defmodule ExTTRPGDev.RuleSystem.Loader do
     )
   end
 
-  defp warn_missing_node_fields(%{type: :mapping} = node, {type_id, concept_id, field}) do
+  defp warn_missing_node_fields(%Node{type: :mapping} = node, {type_id, concept_id, field}) do
     for {key, label} <- [{:input, "input"}, {:steps, "steps"}],
         is_nil(Map.get(node, key)) do
       Logger.warning(
@@ -387,7 +387,7 @@ defmodule ExTTRPGDev.RuleSystem.Loader do
       )
     end
 
-    for {node_key, %{type: :generated, method: method_id}} <- nodes do
+    for {node_key, %Node{type: :generated, method: method_id}} <- nodes do
       warn_generated_method_issue(node_key, method_id, methods, default_ids)
     end
 

--- a/apps/ex_ttrpg_dev/lib/rule_system/loader.ex
+++ b/apps/ex_ttrpg_dev/lib/rule_system/loader.ex
@@ -10,7 +10,7 @@ defmodule ExTTRPGDev.RuleSystem.Loader do
     nodes: %{{type_id, concept_id, field_name} => %Node{}},
     rolling_methods: %{method_id => method_map},
     concept_metadata: %{{type_id, concept_id} => metadata_map},
-    effects: [effect_map]
+    effects: [%Effect{}]
   }
   ```
 
@@ -129,7 +129,7 @@ defmodule ExTTRPGDev.RuleSystem.Loader do
 
   require Logger
 
-  alias ExTTRPGDev.RuleSystem.{Expression, InventoryRules, Node, RuleModule, Vocabulary}
+  alias ExTTRPGDev.RuleSystem.{Effect, Expression, InventoryRules, Node, RuleModule, Vocabulary}
 
   @module_file "module.toml"
   @character_building_file "character_building.toml"
@@ -449,7 +449,7 @@ defmodule ExTTRPGDev.RuleSystem.Loader do
       targets = find_contribution_targets(concept_metadata, contribution, val)
 
       Enum.map(targets, fn target_id ->
-        %{
+        %Effect{
           source: {contribution.from_type, source_id},
           target: {contribution.to_type, target_id, contribution.to_field},
           value: contribution.value,
@@ -540,7 +540,7 @@ defmodule ExTTRPGDev.RuleSystem.Loader do
   defp parse_effect(source, %{"target" => target, "value" => value} = entry) do
     case Expression.parse_ref(target) do
       {:ok, ref} ->
-        %{
+        %Effect{
           source: source,
           target: ref,
           value: value,

--- a/apps/ex_ttrpg_dev/lib/rule_system/node.ex
+++ b/apps/ex_ttrpg_dev/lib/rule_system/node.ex
@@ -1,0 +1,28 @@
+defmodule ExTTRPGDev.RuleSystem.Node do
+  @moduledoc """
+  A single node in a rule system's evaluation DAG.
+
+  The `:type` field determines which other fields are meaningful:
+
+  - `:generated` — leaf value rolled at character generation; `:method` names
+    the rolling method (`nil` falls back to the system default).
+  - `:accumulator` — `:base` formula plus the sum of contributed effects.
+  - `:formula` — `:formula` expression evaluated against resolved nodes.
+  - `:mapping` — `:input` expression looked up in `:steps`
+    (`[[threshold, value], ...]`, thresholds ascending; the value of the last
+    step whose threshold is <= the input wins).
+  """
+
+  @type node_type :: :generated | :accumulator | :formula | :mapping
+
+  @type t :: %__MODULE__{
+          type: node_type(),
+          method: String.t() | nil,
+          base: String.t() | nil,
+          formula: String.t() | nil,
+          input: String.t() | nil,
+          steps: [[number()]] | nil
+        }
+
+  defstruct [:type, :method, :base, :formula, :input, :steps]
+end

--- a/apps/ex_ttrpg_dev/test/characters/apply_award_test.exs
+++ b/apps/ex_ttrpg_dev/test/characters/apply_award_test.exs
@@ -2,6 +2,7 @@ defmodule ExTTRPGDevTest.Characters.ApplyAward do
   use ExUnit.Case, async: true
   alias ExTTRPGDev.Characters
   alias ExTTRPGDev.Characters.Character
+  alias ExTTRPGDev.RuleSystem.Effect
   alias ExTTRPGDev.RuleSystems
 
   setup do
@@ -10,7 +11,7 @@ defmodule ExTTRPGDevTest.Characters.ApplyAward do
   end
 
   defp xp_effect(amount),
-    do: %{target: {"character_trait", "experience_points", "total"}, value: amount}
+    do: %Effect{target: {"character_trait", "experience_points", "total"}, value: amount}
 
   test "integer award with an explicit value appends the effect and returns the value",
        %{system: system, character: character} do

--- a/apps/ex_ttrpg_dev/test/characters/apply_award_test.exs
+++ b/apps/ex_ttrpg_dev/test/characters/apply_award_test.exs
@@ -2,6 +2,7 @@ defmodule ExTTRPGDevTest.Characters.ApplyAward do
   use ExUnit.Case, async: true
   alias ExTTRPGDev.Characters
   alias ExTTRPGDev.Characters.Character
+  alias ExTTRPGDev.Characters.Decision
   alias ExTTRPGDev.RuleSystem.Effect
   alias ExTTRPGDev.RuleSystems
 
@@ -57,7 +58,7 @@ defmodule ExTTRPGDevTest.Characters.ApplyAward do
   end
 
   test "recomputes pending choice slots for the awarded state", %{system: system} do
-    decisions = [%{scope: nil, choice: "class", selection: "wizard"}]
+    decisions = [%Decision{scope: nil, choice: "class", selection: "wizard"}]
     character = Character.gen_character!(system, decisions)
 
     character = %{

--- a/apps/ex_ttrpg_dev/test/characters/character_test.exs
+++ b/apps/ex_ttrpg_dev/test/characters/character_test.exs
@@ -1,7 +1,7 @@
 defmodule ExTTRPGDevTest.Characters.Character do
   use ExUnit.Case
   alias ExTTRPGDev.RuleSystem.Effect
-  alias ExTTRPGDev.Characters.{Character, InventoryItem}
+  alias ExTTRPGDev.Characters.{Character, Decision, InventoryItem}
   alias ExTTRPGDev.RuleSystems
 
   doctest ExTTRPGDev.Characters.Character,
@@ -62,8 +62,8 @@ defmodule ExTTRPGDevTest.Characters.Character do
     system = RuleSystems.load_system!("dnd_5e_srd")
 
     decisions = [
-      %{scope: nil, choice: "race", selection: "hill_dwarf"},
-      %{scope: {"race", "dwarf"}, choice: "subrace", selection: "hill_dwarf"}
+      %Decision{scope: nil, choice: "race", selection: "hill_dwarf"},
+      %Decision{scope: {"race", "dwarf"}, choice: "subrace", selection: "hill_dwarf"}
     ]
 
     character = Character.gen_character!(system, decisions)
@@ -108,7 +108,7 @@ defmodule ExTTRPGDevTest.Characters.Character do
         }
       })
 
-    decisions = [%{scope: nil, choice: "class", selection: "fighter"}]
+    decisions = [%Decision{scope: nil, choice: "class", selection: "fighter"}]
     character = Character.gen_character!(system, decisions)
 
     assert length(character.inventory) == 2
@@ -132,7 +132,7 @@ defmodule ExTTRPGDevTest.Characters.Character do
         }
       })
 
-    decisions = [%{scope: nil, choice: "class", selection: "fighter"}]
+    decisions = [%Decision{scope: nil, choice: "class", selection: "fighter"}]
     character = Character.gen_character!(system, decisions)
     assert character.inventory == []
   end
@@ -164,7 +164,7 @@ defmodule ExTTRPGDevTest.Characters.Character do
       })
 
     decisions = [
-      %{scope: {"class", "fighter"}, choice: "starting_weapon", selection: "longsword"}
+      %Decision{scope: {"class", "fighter"}, choice: "starting_weapon", selection: "longsword"}
     ]
 
     character = Character.gen_character!(system, decisions)
@@ -221,8 +221,8 @@ defmodule ExTTRPGDevTest.Characters.Character do
     system = RuleSystems.load_system!("dnd_5e_srd")
 
     decisions = [
-      %{scope: nil, choice: "race", selection: "dwarf"},
-      %{scope: {"race", "dwarf"}, choice: "subrace", selection: "hill_dwarf"}
+      %Decision{scope: nil, choice: "race", selection: "dwarf"},
+      %Decision{scope: {"race", "dwarf"}, choice: "subrace", selection: "hill_dwarf"}
     ]
 
     original = Character.gen_character!(system, decisions)
@@ -230,6 +230,32 @@ defmodule ExTTRPGDevTest.Characters.Character do
     restored = Character.from_json!(json)
 
     assert restored.decisions == decisions
+  end
+
+  test "to_json_map/1 keeps the stable saved-character JSON shape" do
+    system = RuleSystems.load_system!("dnd_5e_srd")
+
+    decisions = [
+      %Decision{scope: nil, choice: "race", selection: "dwarf"},
+      %Decision{scope: {"race", "dwarf"}, choice: "subrace", selection: "hill_dwarf"}
+    ]
+
+    original = Character.gen_character!(system, decisions)
+
+    original = %{
+      original
+      | effects: [%Effect{target: {"ability", "strength", "total_score"}, value: 2}]
+    }
+
+    json_map = Character.to_json_map(original)
+
+    assert %{"scope" => nil, "choice" => "race", "selection" => "dwarf"} in json_map["decisions"]
+
+    assert %{"scope" => "race:dwarf", "choice" => "subrace", "selection" => "hill_dwarf"} in json_map[
+             "decisions"
+           ]
+
+    assert json_map["effects"] == [%{"target" => "ability:strength:total_score", "value" => 2}]
   end
 
   test "to_json_map/1 and from_json!/1 round-trip preserves effects" do

--- a/apps/ex_ttrpg_dev/test/characters/character_test.exs
+++ b/apps/ex_ttrpg_dev/test/characters/character_test.exs
@@ -1,5 +1,6 @@
 defmodule ExTTRPGDevTest.Characters.Character do
   use ExUnit.Case
+  alias ExTTRPGDev.RuleSystem.Effect
   alias ExTTRPGDev.Characters.{Character, InventoryItem}
   alias ExTTRPGDev.RuleSystems
 
@@ -238,8 +239,8 @@ defmodule ExTTRPGDevTest.Characters.Character do
     original = %{
       original
       | effects: [
-          %{target: {"ability", "strength", "total_score"}, value: 2},
-          %{target: {"ability", "dexterity", "total_score"}, value: -1}
+          %Effect{target: {"ability", "strength", "total_score"}, value: 2},
+          %Effect{target: {"ability", "dexterity", "total_score"}, value: -1}
         ]
     }
 
@@ -248,8 +249,8 @@ defmodule ExTTRPGDevTest.Characters.Character do
 
     assert length(restored.effects) == 2
 
-    assert %{target: {"ability", "strength", "total_score"}, value: 2} in restored.effects
+    assert %Effect{target: {"ability", "strength", "total_score"}, value: 2} in restored.effects
 
-    assert %{target: {"ability", "dexterity", "total_score"}, value: -1} in restored.effects
+    assert %Effect{target: {"ability", "dexterity", "total_score"}, value: -1} in restored.effects
   end
 end

--- a/apps/ex_ttrpg_dev/test/characters/resolve_progression_choice_test.exs
+++ b/apps/ex_ttrpg_dev/test/characters/resolve_progression_choice_test.exs
@@ -2,6 +2,7 @@ defmodule ExTTRPGDevTest.Characters.ResolveProgressionChoice do
   use ExUnit.Case, async: true
   alias ExTTRPGDev.Characters
   alias ExTTRPGDev.Characters.Character
+  alias ExTTRPGDev.RuleSystem.Effect
   alias ExTTRPGDev.RuleSystems
 
   setup do
@@ -109,7 +110,7 @@ defmodule ExTTRPGDevTest.Characters.ResolveProgressionChoice do
                7
              )
 
-    assert %{target: {"character_trait", "max_hit_points", "points"}, value: 7} in updated.effects
+    assert %Effect{target: {"character_trait", "max_hit_points", "points"}, value: 7} in updated.effects
 
     assert %{
              scope: {"character_progression", "hp_per_level"},

--- a/apps/ex_ttrpg_dev/test/characters/resolve_progression_choice_test.exs
+++ b/apps/ex_ttrpg_dev/test/characters/resolve_progression_choice_test.exs
@@ -2,6 +2,7 @@ defmodule ExTTRPGDevTest.Characters.ResolveProgressionChoice do
   use ExUnit.Case, async: true
   alias ExTTRPGDev.Characters
   alias ExTTRPGDev.Characters.Character
+  alias ExTTRPGDev.Characters.Decision
   alias ExTTRPGDev.RuleSystem.Effect
   alias ExTTRPGDev.RuleSystems
 
@@ -9,9 +10,9 @@ defmodule ExTTRPGDevTest.Characters.ResolveProgressionChoice do
     system = RuleSystems.load_system!("dnd_5e_srd")
 
     decisions = [
-      %{scope: nil, choice: "class", selection: "wizard"},
-      %{scope: nil, choice: "race", selection: "human"},
-      %{scope: nil, choice: "background", selection: "soldier"}
+      %Decision{scope: nil, choice: "class", selection: "wizard"},
+      %Decision{scope: nil, choice: "race", selection: "human"},
+      %Decision{scope: nil, choice: "background", selection: "soldier"}
     ]
 
     character = Character.gen_character!(system, decisions)
@@ -39,7 +40,7 @@ defmodule ExTTRPGDevTest.Characters.ResolveProgressionChoice do
     assert {:ok, updated} =
              Characters.resolve_progression_choice(ctx.system, ctx.character, "cantrips", cantrip)
 
-    assert %{
+    assert %Decision{
              scope: {"character_progression", "cantrips"},
              choice: "choice_1",
              selection: ^cantrip
@@ -112,7 +113,7 @@ defmodule ExTTRPGDevTest.Characters.ResolveProgressionChoice do
 
     assert %Effect{target: {"character_trait", "max_hit_points", "points"}, value: 7} in updated.effects
 
-    assert %{
+    assert %Decision{
              scope: {"character_progression", "hp_per_level"},
              choice: "choice_1",
              selection: "rolled"

--- a/apps/ex_ttrpg_dev/test/characters/xp_to_next_level_test.exs
+++ b/apps/ex_ttrpg_dev/test/characters/xp_to_next_level_test.exs
@@ -1,0 +1,38 @@
+defmodule ExTTRPGDevTest.Characters.XpToNextLevel do
+  use ExUnit.Case, async: true
+  alias ExTTRPGDev.Characters
+  alias ExTTRPGDev.Characters.Character
+  alias ExTTRPGDev.RuleSystem.Effect
+  alias ExTTRPGDev.RuleSystems
+
+  setup do
+    {:ok, system: RuleSystems.load_system!("dnd_5e_srd")}
+  end
+
+  defp xp_effect(amount),
+    do: %Effect{target: {"character_trait", "experience_points", "total"}, value: amount}
+
+  test "returns xp_needed and next_level for a level 1 character with no xp", %{system: system} do
+    character = %Character{effects: []}
+    assert {:ok, 300, 2} = Characters.xp_to_next_level(system, character)
+  end
+
+  test "accounts for accumulated xp when computing xp still needed", %{system: system} do
+    character = %Character{effects: [xp_effect(6500)]}
+    # level 5 (6500 XP) → level 6 requires 14000; 14000 - 6500 = 7500 more needed
+    assert {:ok, 7500, 6} = Characters.xp_to_next_level(system, character)
+  end
+
+  test "returns :max_level for a character at the highest level", %{system: system} do
+    character = %Character{effects: [xp_effect(305_000)]}
+    assert {:error, :max_level} = Characters.xp_to_next_level(system, character)
+  end
+
+  test "returns :no_level_thresholds for a system without a level node", %{system: system} do
+    system_no_thresholds = %{system | module: %{system.module | level_node: nil}}
+    character = %Character{effects: []}
+
+    assert {:error, :no_level_thresholds} =
+             Characters.xp_to_next_level(system_no_thresholds, character)
+  end
+end

--- a/apps/ex_ttrpg_dev/test/characters_test.exs
+++ b/apps/ex_ttrpg_dev/test/characters_test.exs
@@ -1,7 +1,7 @@
 defmodule ExTTRPGDevTest.Characters do
   use ExUnit.Case
   alias ExTTRPGDev.Characters
-  alias ExTTRPGDev.Characters.{Character, InventoryItem}
+  alias ExTTRPGDev.Characters.{Character, Decision, InventoryItem}
   alias ExTTRPGDev.RuleSystem.Effect
   alias ExTTRPGDev.RuleSystem.InventoryRules
   alias ExTTRPGDev.RuleSystem.Node
@@ -113,7 +113,7 @@ defmodule ExTTRPGDevTest.Characters do
     end
 
     test "returns root concept for a single root decision" do
-      decisions = [%{scope: nil, choice: "race", selection: "human"}]
+      decisions = [%Decision{scope: nil, choice: "race", selection: "human"}]
       result = Characters.active_concepts(decisions, %{})
       assert MapSet.member?(result, {"race", "human"})
     end
@@ -126,8 +126,8 @@ defmodule ExTTRPGDevTest.Characters do
 
     test "recurses into sub-choices when a decision exists for them" do
       decisions = [
-        %{scope: nil, choice: "race", selection: "dwarf"},
-        %{scope: {"race", "dwarf"}, choice: "subrace", selection: "hill_dwarf"}
+        %Decision{scope: nil, choice: "race", selection: "dwarf"},
+        %Decision{scope: {"race", "dwarf"}, choice: "subrace", selection: "hill_dwarf"}
       ]
 
       result = Characters.active_concepts(decisions, @dwarf_metadata)
@@ -136,7 +136,7 @@ defmodule ExTTRPGDevTest.Characters do
     end
 
     test "does not activate sub-concept when no decision is made for a choice" do
-      decisions = [%{scope: nil, choice: "race", selection: "dwarf"}]
+      decisions = [%Decision{scope: nil, choice: "race", selection: "dwarf"}]
       result = Characters.active_concepts(decisions, @dwarf_metadata)
       assert MapSet.member?(result, {"race", "dwarf"})
       refute MapSet.member?(result, {"race", "hill_dwarf"})
@@ -156,8 +156,8 @@ defmodule ExTTRPGDevTest.Characters do
 
     test "does not recurse into choices with grants_to: inventory" do
       decisions = [
-        %{scope: nil, choice: "class", selection: "fighter"},
-        %{scope: {"class", "fighter"}, choice: "starting_armor", selection: "chain_mail"}
+        %Decision{scope: nil, choice: "class", selection: "fighter"},
+        %Decision{scope: {"class", "fighter"}, choice: "starting_armor", selection: "chain_mail"}
       ]
 
       result = Characters.active_concepts(decisions, @fighter_with_inventory_choice)
@@ -273,7 +273,10 @@ defmodule ExTTRPGDevTest.Characters do
 
     test "includes system effects for active concepts" do
       system = minimal_system([@fighter_effect], %{{"class", "fighter"} => %{}})
-      character = minimal_character([%{scope: nil, choice: "class", selection: "fighter"}])
+
+      character =
+        minimal_character([%Decision{scope: nil, choice: "class", selection: "fighter"}])
+
       effects = Characters.active_effects(system, character)
       assert Enum.any?(effects, &(&1.source == {"class", "fighter"}))
     end
@@ -303,7 +306,11 @@ defmodule ExTTRPGDevTest.Characters do
 
       character =
         minimal_character([
-          %{scope: {"class", "fighter"}, choice: "skill_proficiency_1", selection: "athletics"}
+          %Decision{
+            scope: {"class", "fighter"},
+            choice: "skill_proficiency_1",
+            selection: "athletics"
+          }
         ])
 
       effects = Characters.active_effects(system, character)
@@ -379,7 +386,7 @@ defmodule ExTTRPGDevTest.Characters do
 
       character =
         minimal_character([
-          %{scope: {"race", "elf"}, choice: "subrace", selection: "high_elf"}
+          %Decision{scope: {"race", "elf"}, choice: "subrace", selection: "high_elf"}
         ])
 
       assert Characters.active_effects(system, character) == []
@@ -430,7 +437,7 @@ defmodule ExTTRPGDevTest.Characters do
       system = progression_system(%{"hp_per_level" => @hp_progression})
 
       decisions = [
-        %{
+        %Decision{
           scope: {"character_progression", "hp_per_level"},
           choice: "choice_1",
           selection: "rolled"
@@ -446,12 +453,12 @@ defmodule ExTTRPGDevTest.Characters do
       system = progression_system(%{"hp_per_level" => @hp_progression})
 
       decisions = [
-        %{
+        %Decision{
           scope: {"character_progression", "hp_per_level"},
           choice: "choice_1",
           selection: "rolled"
         },
-        %{
+        %Decision{
           scope: {"character_progression", "hp_per_level"},
           choice: "choice_2",
           selection: "average"
@@ -468,7 +475,11 @@ defmodule ExTTRPGDevTest.Characters do
         progression_system(%{"hp_per_level" => @hp_progression, "other" => @hp_progression})
 
       decisions = [
-        %{scope: {"character_progression", "other"}, choice: "choice_1", selection: "rolled"}
+        %Decision{
+          scope: {"character_progression", "other"},
+          choice: "choice_1",
+          selection: "rolled"
+        }
       ]
 
       result = Characters.pending_choices(system, minimal_character(decisions), @level_binding)
@@ -539,7 +550,7 @@ defmodule ExTTRPGDevTest.Characters do
       }
 
       system = minimal_system([], concept_metadata)
-      decisions = [%{scope: nil, choice: "class", selection: "fighter"}]
+      decisions = [%Decision{scope: nil, choice: "class", selection: "fighter"}]
       [entry] = Characters.pending_choices(system, minimal_character(decisions), @level_binding)
       assert entry.roll == "d10"
     end
@@ -603,7 +614,7 @@ defmodule ExTTRPGDevTest.Characters do
     test "spell progression includes options filtered by level and active class" do
       system = spell_system(%{"cantrips" => @cantrip_progression}, @spell_meta)
 
-      decisions = [%{scope: nil, choice: "class", selection: "wizard"}]
+      decisions = [%Decision{scope: nil, choice: "class", selection: "wizard"}]
       [entry] = Characters.pending_choices(system, minimal_character(decisions), %{})
 
       assert entry.id == "cantrips"
@@ -635,7 +646,7 @@ defmodule ExTTRPGDevTest.Characters do
 
       system = spell_system(%{"spells_known" => progression}, @spell_meta)
       resolved = %{{"character_trait", "max_spell_level", "level"} => 1}
-      decisions = [%{scope: nil, choice: "class", selection: "cleric"}]
+      decisions = [%Decision{scope: nil, choice: "class", selection: "cleric"}]
 
       [entry] = Characters.pending_choices(system, minimal_character(decisions), resolved)
 
@@ -663,7 +674,7 @@ defmodule ExTTRPGDevTest.Characters do
       system = spell_system(%{"spells_known" => progression}, spell_meta)
       # resolved says max_spell_level = 3, but the slot was earned when only level 1 was available
       resolved = %{{"character_trait", "max_spell_level", "level"} => 3}
-      decisions = [%{scope: nil, choice: "class", selection: "cleric"}]
+      decisions = [%Decision{scope: nil, choice: "class", selection: "cleric"}]
 
       pending_choice_slots = [
         %{progression_id: "spells_known", earned_at_level: 1, max_level_cap: 1}
@@ -684,9 +695,9 @@ defmodule ExTTRPGDevTest.Characters do
       generated = Map.new(attrs, &{{"ability", &1, "base_score"}, 10})
 
       decisions = [
-        %{scope: nil, choice: "class", selection: "sorcerer"},
-        %{scope: nil, choice: "race", selection: "human"},
-        %{scope: nil, choice: "background", selection: "acolyte"}
+        %Decision{scope: nil, choice: "class", selection: "sorcerer"},
+        %Decision{scope: nil, choice: "race", selection: "human"},
+        %Decision{scope: nil, choice: "background", selection: "acolyte"}
       ]
 
       character = %Character{
@@ -733,7 +744,7 @@ defmodule ExTTRPGDevTest.Characters do
     test "already-decided slots are excluded from result",
          %{system: system, character: character} do
       # Pre-make one spell decision
-      spell_decision = %{
+      spell_decision = %Decision{
         scope: {"character_progression", "spells_known"},
         choice: "choice_1",
         selection: "fire_bolt"
@@ -804,40 +815,6 @@ defmodule ExTTRPGDevTest.Characters do
       assert_raise RuntimeError, ~r/not found/, fn ->
         Characters.concept_roll!(system, character, "skill", "not_a_real_skill")
       end
-    end
-  end
-
-  describe "xp_to_next_level/2" do
-    setup do
-      {:ok, system: RuleSystems.load_system!("dnd_5e_srd")}
-    end
-
-    defp xp_effect(amount),
-      do: %Effect{target: {"character_trait", "experience_points", "total"}, value: amount}
-
-    test "returns xp_needed and next_level for a level 1 character with no xp", %{system: system} do
-      character = %Character{effects: []}
-      assert {:ok, 300, 2} = Characters.xp_to_next_level(system, character)
-    end
-
-    test "accounts for accumulated xp when computing xp still needed", %{system: system} do
-      character = %Character{effects: [xp_effect(6500)]}
-      # level 5 (6500 XP) → level 6 requires 14000; 14000 - 6500 = 7500 more needed
-      assert {:ok, 7500, 6} = Characters.xp_to_next_level(system, character)
-    end
-
-    test "returns :max_level for a character at the highest level", %{system: system} do
-      character = %Character{effects: [xp_effect(305_000)]}
-      assert {:error, :max_level} = Characters.xp_to_next_level(system, character)
-    end
-
-    test "returns :no_level_thresholds for a system without a level node" do
-      system = RuleSystems.load_system!("dnd_5e_srd")
-      system_no_thresholds = %{system | module: %{system.module | level_node: nil}}
-      character = %Character{effects: []}
-
-      assert {:error, :no_level_thresholds} =
-               Characters.xp_to_next_level(system_no_thresholds, character)
     end
   end
 
@@ -930,7 +907,7 @@ defmodule ExTTRPGDevTest.Characters do
 
     defp asi_sub_choices do
       decisions = [
-        %{
+        %Decision{
           scope: {"character_progression", "asi_or_feat"},
           choice: "choice_1",
           selection: "ability_score_improvement"
@@ -956,12 +933,12 @@ defmodule ExTTRPGDevTest.Characters do
 
     test "sub-choice count decreases as decisions are resolved" do
       decisions = [
-        %{
+        %Decision{
           scope: {"character_progression", "asi_or_feat"},
           choice: "choice_1",
           selection: "ability_score_improvement"
         },
-        %{
+        %Decision{
           scope: {"feat", "ability_score_improvement"},
           choice: "asi_point_1",
           selection: "strength"
@@ -977,17 +954,17 @@ defmodule ExTTRPGDevTest.Characters do
 
     test "no sub-choices remain after all points resolved" do
       decisions = [
-        %{
+        %Decision{
           scope: {"character_progression", "asi_or_feat"},
           choice: "choice_1",
           selection: "ability_score_improvement"
         },
-        %{
+        %Decision{
           scope: {"feat", "ability_score_improvement"},
           choice: "asi_point_1",
           selection: "strength"
         },
-        %{
+        %Decision{
           scope: {"feat", "ability_score_improvement"},
           choice: "asi_point_2",
           selection: "dexterity"
@@ -1233,7 +1210,7 @@ defmodule ExTTRPGDevTest.Characters do
 
     test "returns error when class preparation mode is not prepared" do
       meta = %{{"class", "bard"} => %{"preparation_mode" => "all"}}
-      character = minimal_character([%{scope: nil, choice: "class", selection: "bard"}])
+      character = minimal_character([%Decision{scope: nil, choice: "class", selection: "bard"}])
 
       assert {:error, {:mode_not_prepared, "all"}} =
                Characters.activate(spell_system(meta), character, "spell", [])
@@ -1273,13 +1250,13 @@ defmodule ExTTRPGDevTest.Characters do
       }
 
       decisions = [
-        %{scope: nil, choice: "class", selection: "wizard"},
-        %{
+        %Decision{scope: nil, choice: "class", selection: "wizard"},
+        %Decision{
           scope: {"character_progression", "spells_known"},
           choice: "choice_1",
           selection: "fire_bolt"
         },
-        %{
+        %Decision{
           scope: {"character_progression", "spells_known"},
           choice: "choice_2",
           selection: "cure_wounds"
@@ -1344,8 +1321,8 @@ defmodule ExTTRPGDevTest.Characters do
       }
 
       decisions = [
-        %{scope: nil, choice: "class", selection: "wizard"},
-        %{
+        %Decision{scope: nil, choice: "class", selection: "wizard"},
+        %Decision{
           scope: {"character_progression", "spells_known"},
           choice: "choice_1",
           selection: "magic_missile"
@@ -1411,7 +1388,7 @@ defmodule ExTTRPGDevTest.Characters do
         inventory_rules: spell_inv_rules()
       }
 
-      decisions = [%{scope: nil, choice: "class", selection: "cleric"}]
+      decisions = [%Decision{scope: nil, choice: "class", selection: "cleric"}]
 
       inventory = [
         %InventoryItem{
@@ -1455,7 +1432,7 @@ defmodule ExTTRPGDevTest.Characters do
 
     test "determines initial activation from progression config and class condition" do
       meta = %{{"class", "bard"} => %{"preparation_mode" => "all"}}
-      bard_char = minimal_character([%{scope: nil, choice: "class", selection: "bard"}])
+      bard_char = minimal_character([%Decision{scope: nil, choice: "class", selection: "bard"}])
 
       {:ok, cantrip_char} =
         Characters.add_to_typed_inventory(
@@ -1531,8 +1508,12 @@ defmodule ExTTRPGDevTest.Characters do
       }
 
       decisions = [
-        %{scope: nil, choice: "class", selection: "wizard"},
-        %{scope: {"character_progression", "spells_known"}, choice: "c1", selection: "fire_bolt"}
+        %Decision{scope: nil, choice: "class", selection: "wizard"},
+        %Decision{
+          scope: {"character_progression", "spells_known"},
+          choice: "c1",
+          selection: "fire_bolt"
+        }
       ]
 
       inventory = [
@@ -1588,8 +1569,8 @@ defmodule ExTTRPGDevTest.Characters do
       }
 
       decisions = [
-        %{scope: nil, choice: "class", selection: "cleric"},
-        %{scope: {"class", "cleric"}, choice: "subclass", selection: "life_domain"}
+        %Decision{scope: nil, choice: "class", selection: "cleric"},
+        %Decision{scope: {"class", "cleric"}, choice: "subclass", selection: "life_domain"}
       ]
 
       character = minimal_character(decisions)
@@ -1639,9 +1620,9 @@ defmodule ExTTRPGDevTest.Characters do
       }
 
       decisions = [
-        %{scope: nil, choice: "class", selection: "cleric"},
-        %{scope: {"class", "cleric"}, choice: "subclass", selection: "life_domain"},
-        %{scope: nil, choice: "race", selection: "aasimar"}
+        %Decision{scope: nil, choice: "class", selection: "cleric"},
+        %Decision{scope: {"class", "cleric"}, choice: "subclass", selection: "life_domain"},
+        %Decision{scope: nil, choice: "race", selection: "aasimar"}
       ]
 
       character = minimal_character(decisions)

--- a/apps/ex_ttrpg_dev/test/characters_test.exs
+++ b/apps/ex_ttrpg_dev/test/characters_test.exs
@@ -2,6 +2,7 @@ defmodule ExTTRPGDevTest.Characters do
   use ExUnit.Case
   alias ExTTRPGDev.Characters
   alias ExTTRPGDev.Characters.{Character, InventoryItem}
+  alias ExTTRPGDev.RuleSystem.Effect
   alias ExTTRPGDev.RuleSystem.InventoryRules
   alias ExTTRPGDev.RuleSystem.Node
   alias ExTTRPGDev.RuleSystems
@@ -243,7 +244,7 @@ defmodule ExTTRPGDevTest.Characters do
   end
 
   describe "active_effects/2" do
-    @fighter_effect %{
+    @fighter_effect %Effect{
       source: {"class", "fighter"},
       target: {"saving_throw", "strength", "modifier"},
       value: 2
@@ -319,7 +320,7 @@ defmodule ExTTRPGDevTest.Characters do
       system =
         minimal_system(
           [
-            %{
+            %Effect{
               source: {"equipment", "longsword"},
               target: {"character_trait", "ac", "value"},
               value: 2,
@@ -347,7 +348,13 @@ defmodule ExTTRPGDevTest.Characters do
     test "produces one effect entry per inventory item even for the same concept" do
       system =
         minimal_system(
-          [%{source: {"equipment", "shortsword"}, target: {"stat", "atk", "bonus"}, value: 1}],
+          [
+            %Effect{
+              source: {"equipment", "shortsword"},
+              target: {"stat", "atk", "bonus"},
+              value: 1
+            }
+          ],
           %{}
         )
 
@@ -708,7 +715,7 @@ defmodule ExTTRPGDevTest.Characters do
     test "higher-level slots get appropriate caps reflecting spell access at that level",
          %{system: system, character: character} do
       # XP for level 5 (6500)
-      xp_effect = %{target: {"character_trait", "experience_points", "total"}, value: 6500}
+      xp_effect = %Effect{target: {"character_trait", "experience_points", "total"}, value: 6500}
       character = %{character | effects: [xp_effect]}
 
       slots = Characters.compute_pending_choice_slots(system, character)
@@ -806,7 +813,7 @@ defmodule ExTTRPGDevTest.Characters do
     end
 
     defp xp_effect(amount),
-      do: %{target: {"character_trait", "experience_points", "total"}, value: amount}
+      do: %Effect{target: {"character_trait", "experience_points", "total"}, value: amount}
 
     test "returns xp_needed and next_level for a level 1 character with no xp", %{system: system} do
       character = %Character{effects: []}
@@ -1072,7 +1079,12 @@ defmodule ExTTRPGDevTest.Characters do
 
       # Award XP to level 2 to generate HP pending choices
       xp_target = {"character_trait", "experience_points", "total"}
-      character = %{character | effects: character.effects ++ [%{target: xp_target, value: 300}]}
+
+      character = %{
+        character
+        | effects: character.effects ++ [%Effect{target: xp_target, value: 300}]
+      }
+
       slots = Characters.compute_pending_choice_slots(system, character)
       character = %{character | pending_choice_slots: slots}
 

--- a/apps/ex_ttrpg_dev/test/characters_test.exs
+++ b/apps/ex_ttrpg_dev/test/characters_test.exs
@@ -3,6 +3,7 @@ defmodule ExTTRPGDevTest.Characters do
   alias ExTTRPGDev.Characters
   alias ExTTRPGDev.Characters.{Character, InventoryItem}
   alias ExTTRPGDev.RuleSystem.InventoryRules
+  alias ExTTRPGDev.RuleSystem.Node
   alias ExTTRPGDev.RuleSystems
   alias ExTTRPGDev.RuleSystems.LoadedSystem
 
@@ -1228,8 +1229,8 @@ defmodule ExTTRPGDevTest.Characters do
 
     test "toggle_field: sets prepared true for listed items and false for others" do
       nodes = %{
-        {"class", "wizard", "preparation_cap"} => %{type: :accumulator, base: "3"},
-        {"character_trait", "max_spell_level", "level"} => %{type: :accumulator, base: "2"}
+        {"class", "wizard", "preparation_cap"} => %Node{type: :accumulator, base: "3"},
+        {"character_trait", "max_spell_level", "level"} => %Node{type: :accumulator, base: "2"}
       }
 
       concept_metadata = %{
@@ -1299,8 +1300,8 @@ defmodule ExTTRPGDevTest.Characters do
 
     test "toggle_field: preserves cantrips (outside eligible pool) when preparing leveled spells" do
       nodes = %{
-        {"class", "wizard", "preparation_cap"} => %{type: :accumulator, base: "3"},
-        {"character_trait", "max_spell_level", "level"} => %{type: :accumulator, base: "2"}
+        {"class", "wizard", "preparation_cap"} => %Node{type: :accumulator, base: "3"},
+        {"character_trait", "max_spell_level", "level"} => %Node{type: :accumulator, base: "2"}
       }
 
       concept_metadata = %{
@@ -1366,8 +1367,8 @@ defmodule ExTTRPGDevTest.Characters do
 
     test "add_remove: preserves cantrips when preparing leveled spells" do
       nodes = %{
-        {"class", "cleric", "preparation_cap"} => %{type: :accumulator, base: "4"},
-        {"character_trait", "max_spell_level", "level"} => %{type: :accumulator, base: "2"}
+        {"class", "cleric", "preparation_cap"} => %Node{type: :accumulator, base: "4"},
+        {"character_trait", "max_spell_level", "level"} => %Node{type: :accumulator, base: "2"}
       }
 
       concept_metadata = %{
@@ -1487,8 +1488,8 @@ defmodule ExTTRPGDevTest.Characters do
 
     test "returns full preparation state for a character with a prepared-mode class" do
       nodes = %{
-        {"class", "wizard", "preparation_cap"} => %{type: :accumulator, base: "3"},
-        {"character_trait", "max_spell_level", "level"} => %{type: :accumulator, base: "2"}
+        {"class", "wizard", "preparation_cap"} => %Node{type: :accumulator, base: "3"},
+        {"character_trait", "max_spell_level", "level"} => %Node{type: :accumulator, base: "2"}
       }
 
       concept_metadata = %{
@@ -1538,8 +1539,8 @@ defmodule ExTTRPGDevTest.Characters do
 
     test "always_prepared spells from subclass appear and are filtered by max spell level" do
       nodes = %{
-        {"class", "cleric", "preparation_cap"} => %{type: :accumulator, base: "4"},
-        {"character_trait", "max_spell_level", "level"} => %{type: :accumulator, base: "1"}
+        {"class", "cleric", "preparation_cap"} => %Node{type: :accumulator, base: "4"},
+        {"character_trait", "max_spell_level", "level"} => %Node{type: :accumulator, base: "1"}
       }
 
       concept_metadata = %{
@@ -1589,8 +1590,8 @@ defmodule ExTTRPGDevTest.Characters do
 
     test "always_prepared accumulates from all active concepts, not just subclass" do
       nodes = %{
-        {"class", "cleric", "preparation_cap"} => %{type: :accumulator, base: "4"},
-        {"character_trait", "max_spell_level", "level"} => %{type: :accumulator, base: "2"}
+        {"class", "cleric", "preparation_cap"} => %Node{type: :accumulator, base: "4"},
+        {"character_trait", "max_spell_level", "level"} => %Node{type: :accumulator, base: "2"}
       }
 
       concept_metadata = %{

--- a/apps/ex_ttrpg_dev/test/rule_system/evaluator_test.exs
+++ b/apps/ex_ttrpg_dev/test/rule_system/evaluator_test.exs
@@ -1,6 +1,6 @@
 defmodule ExTTRPGDev.RuleSystem.EvaluatorTest do
   use ExUnit.Case, async: true
-  alias ExTTRPGDev.RuleSystem.{Evaluator, Graph, Loader, Node}
+  alias ExTTRPGDev.RuleSystem.{Effect, Evaluator, Graph, Loader, Node}
 
   doctest ExTTRPGDev.RuleSystem.Evaluator
 
@@ -50,7 +50,7 @@ defmodule ExTTRPGDev.RuleSystem.EvaluatorTest do
     system = minimal_system()
     generated = %{{"attr", "strength", "base_score"} => 16}
 
-    effects = [%{target: {"attr", "strength", "total_score"}, value: 2}]
+    effects = [%Effect{target: {"attr", "strength", "total_score"}, value: 2}]
 
     assert {:ok, resolved} = Evaluator.evaluate(system, generated, effects)
     # total_score = 16 + 2 = 18, modifier = floor((18-10)/2) = 4
@@ -79,17 +79,23 @@ defmodule ExTTRPGDev.RuleSystem.EvaluatorTest do
     assert r0[{"char", "level", "value"}] == 1
 
     assert {:ok, r1} =
-             Evaluator.evaluate(system, %{}, [%{target: {"char", "xp", "total"}, value: 300}])
+             Evaluator.evaluate(system, %{}, [
+               %Effect{target: {"char", "xp", "total"}, value: 300}
+             ])
 
     assert r1[{"char", "level", "value"}] == 2
 
     assert {:ok, r2} =
-             Evaluator.evaluate(system, %{}, [%{target: {"char", "xp", "total"}, value: 850}])
+             Evaluator.evaluate(system, %{}, [
+               %Effect{target: {"char", "xp", "total"}, value: 850}
+             ])
 
     assert r2[{"char", "level", "value"}] == 2
 
     assert {:ok, r3} =
-             Evaluator.evaluate(system, %{}, [%{target: {"char", "xp", "total"}, value: 900}])
+             Evaluator.evaluate(system, %{}, [
+               %Effect{target: {"char", "xp", "total"}, value: 900}
+             ])
 
     assert r3[{"char", "level", "value"}] == 3
   end
@@ -115,7 +121,7 @@ defmodule ExTTRPGDev.RuleSystem.EvaluatorTest do
       rolling_methods: %{},
       concept_metadata: %{},
       effects: [
-        %{
+        %Effect{
           source: {"class", "fighter", nil},
           target: {"save", "strength", "modifier"},
           value: "trait('prof').bonus"
@@ -151,7 +157,7 @@ defmodule ExTTRPGDev.RuleSystem.EvaluatorTest do
     test "skips effect when condition evaluates to false" do
       system = minimal_system()
       generated = %{{"attr", "strength", "base_score"} => 16}
-      effects = [%{target: {"attr", "strength", "total_score"}, value: 2, when: "false"}]
+      effects = [%Effect{target: {"attr", "strength", "total_score"}, value: 2, when: "false"}]
 
       assert {:ok, resolved} = Evaluator.evaluate(system, generated, effects)
       assert resolved[{"attr", "strength", "total_score"}] == 16
@@ -160,7 +166,7 @@ defmodule ExTTRPGDev.RuleSystem.EvaluatorTest do
     test "applies effect when condition evaluates to true" do
       system = minimal_system()
       generated = %{{"attr", "strength", "base_score"} => 16}
-      effects = [%{target: {"attr", "strength", "total_score"}, value: 2, when: "true"}]
+      effects = [%Effect{target: {"attr", "strength", "total_score"}, value: 2, when: "true"}]
 
       assert {:ok, resolved} = Evaluator.evaluate(system, generated, effects)
       assert resolved[{"attr", "strength", "total_score"}] == 18
@@ -169,7 +175,7 @@ defmodule ExTTRPGDev.RuleSystem.EvaluatorTest do
     test "applies effect when `when` key is absent (backward compat)" do
       system = minimal_system()
       generated = %{{"attr", "strength", "base_score"} => 16}
-      effects = [%{target: {"attr", "strength", "total_score"}, value: 2}]
+      effects = [%Effect{target: {"attr", "strength", "total_score"}, value: 2}]
 
       assert {:ok, resolved} = Evaluator.evaluate(system, generated, effects)
       assert resolved[{"attr", "strength", "total_score"}] == 18
@@ -195,8 +201,12 @@ defmodule ExTTRPGDev.RuleSystem.EvaluatorTest do
 
       # Effect applies only when flag is active (non-zero)
       effects = [
-        %{target: {"flag", "active", "value"}, value: 1},
-        %{target: {"attr", "strength", "total_score"}, value: 4, when: "flag('active').value"}
+        %Effect{target: {"flag", "active", "value"}, value: 1},
+        %Effect{
+          target: {"attr", "strength", "total_score"},
+          value: 4,
+          when: "flag('active').value"
+        }
       ]
 
       assert {:ok, resolved} = Evaluator.evaluate(system, generated, effects)
@@ -204,7 +214,11 @@ defmodule ExTTRPGDev.RuleSystem.EvaluatorTest do
 
       # Without the flag effect, the condition evaluates to 0 (false)
       effects_no_flag = [
-        %{target: {"attr", "strength", "total_score"}, value: 4, when: "flag('active').value"}
+        %Effect{
+          target: {"attr", "strength", "total_score"},
+          value: 4,
+          when: "flag('active').value"
+        }
       ]
 
       assert {:ok, resolved_no_flag} = Evaluator.evaluate(system, generated, effects_no_flag)
@@ -218,7 +232,7 @@ defmodule ExTTRPGDev.RuleSystem.EvaluatorTest do
       generated = %{{"attr", "strength", "base_score"} => 16}
 
       effects = [
-        %{
+        %Effect{
           target: {"attr", "strength", "total_score"},
           value: 4,
           when: "item.equipped",
@@ -235,7 +249,7 @@ defmodule ExTTRPGDev.RuleSystem.EvaluatorTest do
       generated = %{{"attr", "strength", "base_score"} => 16}
 
       effects = [
-        %{
+        %Effect{
           target: {"attr", "strength", "total_score"},
           value: 4,
           when: "item.equipped",
@@ -253,7 +267,7 @@ defmodule ExTTRPGDev.RuleSystem.EvaluatorTest do
 
       # condition is 0.5, so value formula "item.condition * 4" = 2.0
       effects = [
-        %{
+        %Effect{
           target: {"attr", "strength", "total_score"},
           value: "item.condition * 4",
           item_fields: %{"condition" => 0.5}
@@ -271,7 +285,7 @@ defmodule ExTTRPGDev.RuleSystem.EvaluatorTest do
       # "bonus" is a prefix of "bonus_max"; a per-field replace pass would
       # corrupt "item.bonus_max" into "2_max" when "bonus" replaced first
       effects = [
-        %{
+        %Effect{
           target: {"attr", "strength", "total_score"},
           value: "item.bonus + item.bonus_max",
           item_fields: %{"bonus" => 2, "bonus_max" => 5}
@@ -287,7 +301,7 @@ defmodule ExTTRPGDev.RuleSystem.EvaluatorTest do
       generated = %{{"attr", "strength", "base_score"} => 16}
 
       effects = [
-        %{
+        %Effect{
           target: {"attr", "strength", "total_score"},
           value: "item.nonexistent * 2",
           item_fields: %{"bonus" => 2}
@@ -352,7 +366,7 @@ defmodule ExTTRPGDev.RuleSystem.EvaluatorTest do
 
     test "saving throw modifier increases when proficiency is applied as an effect",
          %{system: system, generated: generated} do
-      effects = [%{target: {"saving_throw", "strength", "modifier"}, value: 2}]
+      effects = [%Effect{target: {"saving_throw", "strength", "modifier"}, value: 2}]
       assert {:ok, resolved} = Evaluator.evaluate(system, generated, effects)
       assert resolved[{"saving_throw", "strength", "modifier"}] == 5
       assert resolved[{"saving_throw", "dexterity", "modifier"}] == 2
@@ -380,7 +394,7 @@ defmodule ExTTRPGDev.RuleSystem.EvaluatorTest do
     defp item_effects(system, concept_id, equipped) do
       system.effects
       |> Enum.filter(fn
-        %{source: {"equipment", id}} -> id == concept_id
+        %Effect{source: {"equipment", id}} -> id == concept_id
         _ -> false
       end)
       |> Enum.map(&Map.put(&1, :item_fields, %{"equipped" => equipped}))
@@ -468,7 +482,7 @@ defmodule ExTTRPGDev.RuleSystem.EvaluatorTest do
 
     defp class_effects(system, class_id) do
       Enum.filter(system.effects, fn
-        %{source: {"class", id}} -> id == class_id
+        %Effect{source: {"class", id}} -> id == class_id
         _ -> false
       end)
     end
@@ -529,7 +543,7 @@ defmodule ExTTRPGDev.RuleSystem.EvaluatorTest do
     end
 
     defp xp_effect(xp),
-      do: %{target: {"character_trait", "experience_points", "total"}, value: xp}
+      do: %Effect{target: {"character_trait", "experience_points", "total"}, value: xp}
 
     # level 1 = 0 XP, level 5 = 6500 XP, level 11 = 85000 XP, level 17 = 225000 XP
     defp spell_slots(resolved) do
@@ -634,7 +648,7 @@ defmodule ExTTRPGDev.RuleSystem.EvaluatorTest do
     # Non-zero number is truthy
     assert {:ok, r1} =
              Evaluator.evaluate(system, generated, [
-               %{target: {"attr", "strength", "total_score"}, value: 2, when: "1"}
+               %Effect{target: {"attr", "strength", "total_score"}, value: 2, when: "1"}
              ])
 
     assert r1[{"attr", "strength", "total_score"}] == 18
@@ -642,7 +656,7 @@ defmodule ExTTRPGDev.RuleSystem.EvaluatorTest do
     # Zero is falsy
     assert {:ok, r2} =
              Evaluator.evaluate(system, generated, [
-               %{target: {"attr", "strength", "total_score"}, value: 2, when: "0"}
+               %Effect{target: {"attr", "strength", "total_score"}, value: 2, when: "0"}
              ])
 
     assert r2[{"attr", "strength", "total_score"}] == 16
@@ -650,7 +664,7 @@ defmodule ExTTRPGDev.RuleSystem.EvaluatorTest do
     # Formula error propagates
     assert {:error, _} =
              Evaluator.evaluate(system, generated, [
-               %{
+               %Effect{
                  target: {"attr", "strength", "total_score"},
                  value: 2,
                  when: "nonexistent('x').y"

--- a/apps/ex_ttrpg_dev/test/rule_system/evaluator_test.exs
+++ b/apps/ex_ttrpg_dev/test/rule_system/evaluator_test.exs
@@ -1,18 +1,18 @@
 defmodule ExTTRPGDev.RuleSystem.EvaluatorTest do
   use ExUnit.Case, async: true
-  alias ExTTRPGDev.RuleSystem.{Evaluator, Graph, Loader}
+  alias ExTTRPGDev.RuleSystem.{Evaluator, Graph, Loader, Node}
 
   doctest ExTTRPGDev.RuleSystem.Evaluator
 
   defp minimal_system do
     loader_data = %{
       nodes: %{
-        {"attr", "strength", "base_score"} => %{type: :generated, method: "standard"},
-        {"attr", "strength", "total_score"} => %{
+        {"attr", "strength", "base_score"} => %Node{type: :generated, method: "standard"},
+        {"attr", "strength", "total_score"} => %Node{
           type: :accumulator,
           base: "attr('strength').base_score"
         },
-        {"attr", "strength", "modifier"} => %{
+        {"attr", "strength", "modifier"} => %Node{
           type: :formula,
           formula: "floor((attr('strength').total_score - 10) / 2)"
         }
@@ -61,8 +61,8 @@ defmodule ExTTRPGDev.RuleSystem.EvaluatorTest do
   test "evaluate/3 resolves mapping node from input value" do
     loader_data = %{
       nodes: %{
-        {"char", "xp", "total"} => %{type: :accumulator, base: "0"},
-        {"char", "level", "value"} => %{
+        {"char", "xp", "total"} => %Node{type: :accumulator, base: "0"},
+        {"char", "level", "value"} => %Node{
           type: :mapping,
           input: "char('xp').total",
           steps: [[0, 1], [300, 2], [900, 3]]
@@ -97,17 +97,17 @@ defmodule ExTTRPGDev.RuleSystem.EvaluatorTest do
   test "evaluate/3 resolves formula-valued effects against current node values" do
     loader_data = %{
       nodes: %{
-        {"trait", "prof", "bonus"} => %{type: :accumulator, base: "2"},
-        {"attr", "strength", "base_score"} => %{type: :generated, method: "standard"},
-        {"attr", "strength", "total_score"} => %{
+        {"trait", "prof", "bonus"} => %Node{type: :accumulator, base: "2"},
+        {"attr", "strength", "base_score"} => %Node{type: :generated, method: "standard"},
+        {"attr", "strength", "total_score"} => %Node{
           type: :accumulator,
           base: "attr('strength').base_score"
         },
-        {"attr", "strength", "modifier"} => %{
+        {"attr", "strength", "modifier"} => %Node{
           type: :formula,
           formula: "floor((attr('strength').total_score - 10) / 2)"
         },
-        {"save", "strength", "modifier"} => %{
+        {"save", "strength", "modifier"} => %Node{
           type: :accumulator,
           base: "attr('strength').modifier"
         }
@@ -178,12 +178,12 @@ defmodule ExTTRPGDev.RuleSystem.EvaluatorTest do
     test "evaluates `when` as a formula referencing resolved nodes" do
       loader_data = %{
         nodes: %{
-          {"attr", "strength", "base_score"} => %{type: :generated, method: "standard"},
-          {"attr", "strength", "total_score"} => %{
+          {"attr", "strength", "base_score"} => %Node{type: :generated, method: "standard"},
+          {"attr", "strength", "total_score"} => %Node{
             type: :accumulator,
             base: "attr('strength').base_score"
           },
-          {"flag", "active", "value"} => %{type: :accumulator, base: "0"}
+          {"flag", "active", "value"} => %Node{type: :accumulator, base: "0"}
         },
         rolling_methods: %{},
         concept_metadata: %{},

--- a/apps/ex_ttrpg_dev/test/rule_system/graph_test.exs
+++ b/apps/ex_ttrpg_dev/test/rule_system/graph_test.exs
@@ -1,16 +1,16 @@
 defmodule ExTTRPGDev.RuleSystem.GraphTest do
   use ExUnit.Case, async: true
-  alias ExTTRPGDev.RuleSystem.{Graph, Loader}
+  alias ExTTRPGDev.RuleSystem.{Graph, Loader, Node}
 
   defp minimal_loader_data do
     %{
       nodes: %{
-        {"attr", "strength", "base_score"} => %{type: :generated, method: "standard"},
-        {"attr", "strength", "total_score"} => %{
+        {"attr", "strength", "base_score"} => %Node{type: :generated, method: "standard"},
+        {"attr", "strength", "total_score"} => %Node{
           type: :accumulator,
           base: "attr('strength').base_score"
         },
-        {"attr", "strength", "modifier"} => %{
+        {"attr", "strength", "modifier"} => %Node{
           type: :formula,
           formula: "floor((attr('strength').total_score - 10) / 2)"
         }
@@ -45,7 +45,7 @@ defmodule ExTTRPGDev.RuleSystem.GraphTest do
   test "build/1 returns error for undefined reference" do
     bad_data = %{
       nodes: %{
-        {"attr", "strength", "modifier"} => %{
+        {"attr", "strength", "modifier"} => %Node{
           type: :formula,
           formula: "attr('strength').total_score"
         }
@@ -61,8 +61,8 @@ defmodule ExTTRPGDev.RuleSystem.GraphTest do
   test "build/1 detects cycles" do
     cyclic_data = %{
       nodes: %{
-        {"attr", "a", "val"} => %{type: :formula, formula: "attr('b').val"},
-        {"attr", "b", "val"} => %{type: :formula, formula: "attr('a').val"}
+        {"attr", "a", "val"} => %Node{type: :formula, formula: "attr('b').val"},
+        {"attr", "b", "val"} => %Node{type: :formula, formula: "attr('a').val"}
       },
       rolling_methods: %{},
       concept_metadata: %{},
@@ -87,8 +87,8 @@ defmodule ExTTRPGDev.RuleSystem.GraphTest do
   test "build/1 adds edge from formula-valued effect's ref to its target" do
     data = %{
       nodes: %{
-        {"trait", "prof", "bonus"} => %{type: :accumulator, base: "2"},
-        {"save", "str", "modifier"} => %{type: :accumulator, base: "0"}
+        {"trait", "prof", "bonus"} => %Node{type: :accumulator, base: "2"},
+        {"save", "str", "modifier"} => %Node{type: :accumulator, base: "0"}
       },
       rolling_methods: %{},
       concept_metadata: %{},
@@ -111,7 +111,7 @@ defmodule ExTTRPGDev.RuleSystem.GraphTest do
   test "build/1 returns error for undefined ref in formula-valued effect" do
     data = %{
       nodes: %{
-        {"save", "str", "modifier"} => %{type: :accumulator, base: "0"}
+        {"save", "str", "modifier"} => %Node{type: :accumulator, base: "0"}
       },
       rolling_methods: %{},
       concept_metadata: %{},
@@ -130,7 +130,7 @@ defmodule ExTTRPGDev.RuleSystem.GraphTest do
   test "build/1 returns error for undefined contribution target" do
     data = %{
       nodes: %{
-        {"attr", "strength", "base_score"} => %{type: :generated, method: "standard"}
+        {"attr", "strength", "base_score"} => %Node{type: :generated, method: "standard"}
       },
       rolling_methods: %{},
       concept_metadata: %{},

--- a/apps/ex_ttrpg_dev/test/rule_system/graph_test.exs
+++ b/apps/ex_ttrpg_dev/test/rule_system/graph_test.exs
@@ -1,24 +1,23 @@
 defmodule ExTTRPGDev.RuleSystem.GraphTest do
   use ExUnit.Case, async: true
-  alias ExTTRPGDev.RuleSystem.{Graph, Loader, Node}
+  alias ExTTRPGDev.RuleSystem.{Effect, Graph, Loader, Node}
+
+  defp graph_data(nodes, effects \\ []) do
+    %{nodes: nodes, rolling_methods: %{}, concept_metadata: %{}, effects: effects}
+  end
 
   defp minimal_loader_data do
-    %{
-      nodes: %{
-        {"attr", "strength", "base_score"} => %Node{type: :generated, method: "standard"},
-        {"attr", "strength", "total_score"} => %Node{
-          type: :accumulator,
-          base: "attr('strength').base_score"
-        },
-        {"attr", "strength", "modifier"} => %Node{
-          type: :formula,
-          formula: "floor((attr('strength').total_score - 10) / 2)"
-        }
+    graph_data(%{
+      {"attr", "strength", "base_score"} => %Node{type: :generated, method: "standard"},
+      {"attr", "strength", "total_score"} => %Node{
+        type: :accumulator,
+        base: "attr('strength').base_score"
       },
-      rolling_methods: %{},
-      concept_metadata: %{},
-      effects: []
-    }
+      {"attr", "strength", "modifier"} => %Node{
+        type: :formula,
+        formula: "floor((attr('strength').total_score - 10) / 2)"
+      }
+    })
   end
 
   defp with_choices(concept_metadata) do
@@ -36,38 +35,30 @@ defmodule ExTTRPGDev.RuleSystem.GraphTest do
   end
 
   test "build/1 rejects a non-tuple effect target" do
-    effect = %{source: {"attr", "strength"}, target: "attr(strength).total_score", value: 2}
+    effect = %Effect{source: {"attr", "strength"}, target: "attr(strength).total_score", value: 2}
     data = Map.put(minimal_loader_data(), :effects, [effect])
 
     assert {:error, {:invalid_effect_target, "attr(strength).total_score"}} = Graph.build(data)
   end
 
   test "build/1 returns error for undefined reference" do
-    bad_data = %{
-      nodes: %{
+    bad_data =
+      graph_data(%{
         {"attr", "strength", "modifier"} => %Node{
           type: :formula,
           formula: "attr('strength').total_score"
         }
-      },
-      rolling_methods: %{},
-      concept_metadata: %{},
-      effects: []
-    }
+      })
 
     assert {:error, {:undefined_ref, _}} = Graph.build(bad_data)
   end
 
   test "build/1 detects cycles" do
-    cyclic_data = %{
-      nodes: %{
+    cyclic_data =
+      graph_data(%{
         {"attr", "a", "val"} => %Node{type: :formula, formula: "attr('b').val"},
         {"attr", "b", "val"} => %Node{type: :formula, formula: "attr('a').val"}
-      },
-      rolling_methods: %{},
-      concept_metadata: %{},
-      effects: []
-    }
+      })
 
     assert {:error, {:cycle_detected, _}} = Graph.build(cyclic_data)
   end
@@ -84,22 +75,21 @@ defmodule ExTTRPGDev.RuleSystem.GraphTest do
     assert total_idx < mod_idx
   end
 
+  @prof_bonus_effect %Effect{
+    source: {"class", "fighter", nil},
+    target: {"save", "str", "modifier"},
+    value: "trait('prof').bonus"
+  }
+
   test "build/1 adds edge from formula-valued effect's ref to its target" do
-    data = %{
-      nodes: %{
-        {"trait", "prof", "bonus"} => %Node{type: :accumulator, base: "2"},
-        {"save", "str", "modifier"} => %Node{type: :accumulator, base: "0"}
-      },
-      rolling_methods: %{},
-      concept_metadata: %{},
-      effects: [
+    data =
+      graph_data(
         %{
-          source: {"class", "fighter", nil},
-          target: {"save", "str", "modifier"},
-          value: "trait('prof').bonus"
-        }
-      ]
-    }
+          {"trait", "prof", "bonus"} => %Node{type: :accumulator, base: "2"},
+          {"save", "str", "modifier"} => %Node{type: :accumulator, base: "0"}
+        },
+        [@prof_bonus_effect]
+      )
 
     assert {:ok, system} = Graph.build(data)
     order = Graph.topological_order(system)
@@ -109,35 +99,27 @@ defmodule ExTTRPGDev.RuleSystem.GraphTest do
   end
 
   test "build/1 returns error for undefined ref in formula-valued effect" do
-    data = %{
-      nodes: %{
-        {"save", "str", "modifier"} => %Node{type: :accumulator, base: "0"}
-      },
-      rolling_methods: %{},
-      concept_metadata: %{},
-      effects: [
-        %{
-          source: {"class", "fighter", nil},
-          target: {"save", "str", "modifier"},
-          value: "trait('prof').bonus"
-        }
-      ]
-    }
+    data =
+      graph_data(
+        %{{"save", "str", "modifier"} => %Node{type: :accumulator, base: "0"}},
+        [@prof_bonus_effect]
+      )
 
     assert {:error, {:undefined_ref, _}} = Graph.build(data)
   end
 
   test "build/1 returns error for undefined contribution target" do
-    data = %{
-      nodes: %{
-        {"attr", "strength", "base_score"} => %Node{type: :generated, method: "standard"}
-      },
-      rolling_methods: %{},
-      concept_metadata: %{},
-      effects: [
-        %{source: {"item", "ring", nil}, target: {"attr", "strength", "nonexistent"}, value: 2}
-      ]
-    }
+    data =
+      graph_data(
+        %{{"attr", "strength", "base_score"} => %Node{type: :generated, method: "standard"}},
+        [
+          %Effect{
+            source: {"item", "ring", nil},
+            target: {"attr", "strength", "nonexistent"},
+            value: 2
+          }
+        ]
+      )
 
     assert {:error, {:undefined_effect_target, _}} = Graph.build(data)
   end

--- a/apps/ex_ttrpg_dev/test/rule_system/loader_test.exs
+++ b/apps/ex_ttrpg_dev/test/rule_system/loader_test.exs
@@ -1,7 +1,7 @@
 defmodule ExTTRPGDev.RuleSystem.LoaderTest do
   use ExUnit.Case, async: true
   import ExUnit.CaptureLog
-  alias ExTTRPGDev.RuleSystem.{InventoryRules, Loader, RuleModule}
+  alias ExTTRPGDev.RuleSystem.{InventoryRules, Loader, Node, RuleModule}
 
   defp dnd_path do
     Application.app_dir(:ex_ttrpg_dev, "priv/system_configs/dnd_5e_srd")
@@ -63,20 +63,20 @@ defmodule ExTTRPGDev.RuleSystem.LoaderTest do
   test "load/1 nodes have correct types" do
     {:ok, data} = Loader.load(dnd_path())
 
-    assert %{type: :generated} = data.nodes[{"ability", "dexterity", "base_score"}]
-    assert %{type: :accumulator} = data.nodes[{"ability", "dexterity", "total_score"}]
-    assert %{type: :formula} = data.nodes[{"ability", "dexterity", "modifier"}]
+    assert %Node{type: :generated} = data.nodes[{"ability", "dexterity", "base_score"}]
+    assert %Node{type: :accumulator} = data.nodes[{"ability", "dexterity", "total_score"}]
+    assert %Node{type: :formula} = data.nodes[{"ability", "dexterity", "modifier"}]
   end
 
   test "load/1 skill nodes are accumulators referencing correct abilities" do
     {:ok, data} = Loader.load(dnd_path())
 
     assert Map.has_key?(data.nodes, {"skill", "acrobatics", "modifier"})
-    %{type: :accumulator, base: base} = data.nodes[{"skill", "acrobatics", "modifier"}]
+    %Node{type: :accumulator, base: base} = data.nodes[{"skill", "acrobatics", "modifier"}]
     assert String.contains?(base, "ability('dexterity')")
 
     assert Map.has_key?(data.nodes, {"skill", "athletics", "modifier"})
-    %{type: :accumulator, base: base} = data.nodes[{"skill", "athletics", "modifier"}]
+    %Node{type: :accumulator, base: base} = data.nodes[{"skill", "athletics", "modifier"}]
     assert String.contains?(base, "ability('strength')")
   end
 
@@ -271,7 +271,7 @@ defmodule ExTTRPGDev.RuleSystem.LoaderTest do
 
     for ability <- ~w(strength dexterity constitution wisdom intelligence charisma) do
       node = data.nodes[{"saving_throw", ability, "modifier"}]
-      assert %{type: :accumulator} = node
+      assert %Node{type: :accumulator} = node
       assert String.contains?(node.base, "ability('#{ability}').modifier")
     end
   end
@@ -285,21 +285,21 @@ defmodule ExTTRPGDev.RuleSystem.LoaderTest do
   test "load/1 returns proficiency_bonus as an accumulator referencing character_level" do
     {:ok, data} = Loader.load(dnd_path())
     node = data.nodes[{"character_trait", "proficiency_bonus", "bonus"}]
-    assert %{type: :accumulator, base: base} = node
+    assert %Node{type: :accumulator, base: base} = node
     assert String.contains?(base, "character_trait('character_level').level")
   end
 
   test "load/1 returns experience_points as an accumulator node" do
     {:ok, data} = Loader.load(dnd_path())
 
-    assert %{type: :accumulator, base: "0"} =
+    assert %Node{type: :accumulator, base: "0"} =
              data.nodes[{"character_trait", "experience_points", "total"}]
   end
 
   test "load/1 returns character_level as a mapping node with 20 XP steps" do
     {:ok, data} = Loader.load(dnd_path())
     node = data.nodes[{"character_trait", "character_level", "level"}]
-    assert %{type: :mapping, steps: steps} = node
+    assert %Node{type: :mapping, steps: steps} = node
     assert length(steps) == 20
     assert List.first(steps) == [0, 1]
     assert List.last(steps) == [305_000, 20]

--- a/apps/ttrpg_dev_cli/lib/cli/serializer.ex
+++ b/apps/ttrpg_dev_cli/lib/cli/serializer.ex
@@ -8,7 +8,7 @@ defmodule ExTTRPGDev.CLI.Serializer do
   """
 
   alias ExTTRPGDev.Characters
-  alias ExTTRPGDev.Characters.{Character, InventoryItem}
+  alias ExTTRPGDev.Characters.{Character, Decision, InventoryItem}
   alias ExTTRPGDev.CLI.ConceptDisplay
   alias ExTTRPGDev.RuleSystem.InventoryRules
   alias ExTTRPGDev.RuleSystems.LoadedSystem
@@ -191,13 +191,13 @@ defmodule ExTTRPGDev.CLI.Serializer do
 
     character.decisions
     |> Enum.filter(fn
-      %{scope: {"character_progression", prog_id}} ->
+      %Decision{scope: {"character_progression", prog_id}} ->
         Map.has_key?(selection_progressions, prog_id)
 
       _ ->
         false
     end)
-    |> Enum.map(fn %{scope: {"character_progression", prog_id}, selection: selection} ->
+    |> Enum.map(fn %Decision{scope: {"character_progression", prog_id}, selection: selection} ->
       prog = selection_progressions[prog_id]
       {prog.concept_type, prog.name, selection}
     end)
@@ -318,7 +318,7 @@ defmodule ExTTRPGDev.CLI.Serializer do
   defp chosen_by_type(decisions, concept_metadata, type) do
     decisions
     |> Enum.filter(fn
-      %{scope: {scope_type, scope_id}, choice: choice_id} ->
+      %Decision{scope: {scope_type, scope_id}, choice: choice_id} ->
         choice_def =
           get_in(concept_metadata, [{scope_type, scope_id}, "choices", choice_id]) || %{}
 

--- a/apps/ttrpg_dev_cli/lib/cli/server/handlers/build.ex
+++ b/apps/ttrpg_dev_cli/lib/cli/server/handlers/build.ex
@@ -7,6 +7,7 @@ defmodule ExTTRPGDev.CLI.Server.Handlers.Build do
 
   alias ExTTRPGDev.Characters
   alias ExTTRPGDev.Characters.Character
+  alias ExTTRPGDev.Characters.Decision
   alias ExTTRPGDev.CLI.Serializer
   alias ExTTRPGDev.CLI.Server.Common
   alias ExTTRPGDev.RuleSystems
@@ -39,7 +40,7 @@ defmodule ExTTRPGDev.CLI.Server.Handlers.Build do
       ) do
     character = Common.fetch_pending!(state, temp_id)
     system = RuleSystems.load_system!(character.metadata.rule_system)
-    decision = %{scope: nil, choice: concept_type, selection: concept_id}
+    decision = %Decision{scope: nil, choice: concept_type, selection: concept_id}
     updated = %{character | decisions: character.decisions ++ [decision]}
 
     sub_choices =
@@ -71,7 +72,7 @@ defmodule ExTTRPGDev.CLI.Server.Handlers.Build do
     choice_def = Characters.fetch_choice_def!(system, scope, choice_id)
     valid = Characters.valid_sub_choices(system, scope, choice_def, character.decisions)
     Common.validate_concept_selection!(selection, valid)
-    decision = %{scope: scope, choice: choice_id, selection: selection}
+    decision = %Decision{scope: scope, choice: choice_id, selection: selection}
     updated = %{character | decisions: character.decisions ++ [decision]}
 
     sub_choices =

--- a/apps/ttrpg_dev_cli/lib/cli/server/handlers/characters.ex
+++ b/apps/ttrpg_dev_cli/lib/cli/server/handlers/characters.ex
@@ -9,6 +9,7 @@ defmodule ExTTRPGDev.CLI.Server.Handlers.Characters do
 
   alias ExTTRPGDev.Characters
   alias ExTTRPGDev.Characters.Character
+  alias ExTTRPGDev.Characters.Decision
   alias ExTTRPGDev.CLI.Serializer
   alias ExTTRPGDev.CLI.Server.Common
   alias ExTTRPGDev.CLI.Server.Errors
@@ -157,7 +158,7 @@ defmodule ExTTRPGDev.CLI.Server.Handlers.Characters do
     valid = Characters.valid_sub_choices(system, scope, choice_def, character.decisions)
     Common.validate_concept_selection!(selection, valid)
 
-    decision = %{scope: scope, choice: choice_id, selection: selection}
+    decision = %Decision{scope: scope, choice: choice_id, selection: selection}
     updated = %{character | decisions: character.decisions ++ [decision]}
     Characters.save_character!(updated, true)
 


### PR DESCRIPTION
Closes #133.

## What

Three commits, one struct each, replacing the shapeless maps whose schemas existed only as the union of their producers:

1. **`RuleSystem.Node`** — `:type` (`:generated | :accumulator | :formula | :mapping`) plus per-type fields, with a typespec documenting which fields each type uses. Loader constructs; Graph/Evaluator/Characters/Character match on the struct. Nodes are never persisted, so no serialization concerns. (Pending-choice entries — `%{type: :pending}` — are a different, caller-facing shape and deliberately remain maps.)

2. **`RuleSystem.Effect`** — full shape declared, with `item_fields` a real field defaulting to `%{}` (previously bolted on by `inventory_effects` via `Map.put` and read defensively by the Evaluator with `Map.get(effect, :item_fields, %{})`) and `source: nil` for effects the character carries directly. The Evaluator now destructures `%Effect{}`; attaching item fields is a checked struct update.

3. **`Characters.Decision`** — shape + `new/3` + JSON encoding as `to_json_map`/`from_json_map`, moved verbatim from `Character`'s private `serialize_decision`/`deserialize_decision`. All ~15 construction/matching sites across the library and CLI use the struct.

## Format safety

Saved-character JSON is byte-identical to before. Beyond the existing round-trip tests (which now assert struct equality end-to-end), a new test pins the exact on-disk shape — decision scope `"type:id"` strings, effect target `"type:id:field"` strings — so a future struct change cannot silently alter saved files.

## Notes

- No bare-map node/effect/decision literals remain in library or CLI logic (verified by grep).
- Test updates are struct-literal conversions plus two code-health-driven reorganizations: a `graph_data/2` helper in `graph_test.exs`, and the `xp_to_next_level/2` block moving to its own file (`characters_test.exs` crossed the 1000-line threshold).
- All 383 tests pass; `--warnings-as-errors` (the type checker's struct-update check caught one capture-syntax issue during development), credo, and dialyzer clean.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored character and rule system logic to use explicit structs (Decision, Effect) instead of generic maps.</li>
<li>Updated character progression and decision-making functions to utilize the new Decision struct.</li>
<li>Updated effect evaluation logic to use the Effect struct.</li>
<li>Added corresponding unit tests to verify the new struct-based implementations.</li>
</ul></div>